### PR TITLE
Use correct env variable in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Have a look at the Dockerfile for a full example of how to run this application.
 | `SECRET_JWT_SECRET`           | Override this for the secret signin JWT tokens for log in             | good_luck_have_fun |
 | `SECRET_FILE_SIZE`            | Set the total allowed upload file size in mb.                         | 4                  |
 | `SECRET_ENABLE_FILE_UPLOAD`   | Enable or disable file upload                                         | true               |
-| `SECRET_USER_DISABLE`         | Disable user registration                                             | false              |
+| `SECRET_DISABLE_USERS`        | Disable user registration                                            | false              |
 | `SECRET_FORCED_LANGUAGE`      | Set the default language for the application.                         | en                 |
 | `SECRET_DO_SPACES_ENDPOINT`   | The Digital Ocean Spaces/AWS s3 endpoint                              | ""                 |
 | `SECRET_DO_SPACES_KEY`        | The Digital Ocean Spaces/AWS s3 key                                   | ""                 |


### PR DESCRIPTION
I figured out, that the correct variable name is `SECRET_DISABLE_USERS`, instead of `SECRET_USER_DISABLE`.