### PR TITLE
Fix for issue #107: Leverage the redux state for sign in / out

### DIFF
--- a/src/client/actions/index.js
+++ b/src/client/actions/index.js
@@ -1,3 +1,15 @@
-export function userLoginChanged(payload) {
-    return { type: 'USER_LOGIN_CHANGED', payload };
-}
+import { USER_LOGIN_CHANGED, USER_LOGIN } from '../util/constants';
+
+export const userLoginChanged = (payload) => {
+    return {
+        type: USER_LOGIN_CHANGED,
+        payload,
+    };
+};
+
+export const userLogin = (payload) => {
+    return {
+        type: USER_LOGIN,
+        payload,
+    };
+};

--- a/src/client/components/header/index.js
+++ b/src/client/components/header/index.js
@@ -2,9 +2,9 @@ import { Link, Redirect } from 'react-router-dom';
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Anchor, Button, Container, Group, Grid } from '@mantine/core';
-import { IconLockOff, IconLogin } from '@tabler/icons';
+import { IconDeviceDesktopAnalytics, IconLockOff, IconLogin } from '@tabler/icons';
 import { useTranslation } from 'react-i18next';
-import { userLoginChanged } from '../../actions/';
+import { userLoginChanged, userLogin } from '../../actions/';
 import Logo from './logo.js';
 import { hasToken, removeToken } from '../../helpers/token';
 import config from '../../config';
@@ -27,7 +27,7 @@ const Header = () => {
         event.preventDefault();
 
         removeToken();
-
+        dispatch(userLogin(null));
         dispatch(userLoginChanged(false));
 
         setOnSignOutRedirect(true);

--- a/src/client/components/header/index.js
+++ b/src/client/components/header/index.js
@@ -2,7 +2,7 @@ import { Link, Redirect } from 'react-router-dom';
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Anchor, Button, Container, Group, Grid } from '@mantine/core';
-import { IconDeviceDesktopAnalytics, IconLockOff, IconLogin } from '@tabler/icons';
+import { IconLockOff, IconLogin } from '@tabler/icons';
 import { useTranslation } from 'react-i18next';
 import { userLoginChanged, userLogin } from '../../actions/';
 import Logo from './logo.js';

--- a/src/client/reducers/index.js
+++ b/src/client/reducers/index.js
@@ -1,11 +1,15 @@
+import { USER_LOGIN_CHANGED, USER_LOGIN } from '../util/constants';
+
 const initialState = {
     isLoggedIn: false,
 };
 
 export default function rootReducer(state = initialState, action) {
     switch (action.type) {
-        case 'USER_LOGIN_CHANGED':
+        case USER_LOGIN_CHANGED:
             return { ...state, isLoggedIn: action.payload };
+        case USER_LOGIN:
+            return { ...state, token: action.payload };
         default:
             return state;
     }

--- a/src/client/routes/account/index.js
+++ b/src/client/routes/account/index.js
@@ -34,7 +34,6 @@ const Account = () => {
     const [activeTab, setActiveTab] = useState('account');
 
     const dispatch = useDispatch();
-    console.log(useSelector((state) => console.log(state)));
 
     const form = useForm({
         initialValues: {

--- a/src/client/routes/account/index.js
+++ b/src/client/routes/account/index.js
@@ -13,7 +13,7 @@ import { useForm } from '@mantine/form';
 import { openConfirmModal } from '@mantine/modals';
 import { IconUser, IconAt, IconLock, IconTrash, IconSettings, IconEdit } from '@tabler/icons';
 import { Redirect } from 'react-router-dom';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { getToken, hasToken, removeToken } from '../../helpers/token';
 import { userLoginChanged } from '../../actions';
 
@@ -34,6 +34,7 @@ const Account = () => {
     const [activeTab, setActiveTab] = useState('account');
 
     const dispatch = useDispatch();
+    console.log(useSelector((state) => console.log(state)));
 
     const form = useForm({
         initialValues: {

--- a/src/client/routes/signin/index.js
+++ b/src/client/routes/signin/index.js
@@ -1,17 +1,20 @@
 import React, { useEffect, useState } from 'react';
 import { Redirect } from 'react-router-dom';
 import { Button, Container, TextInput, Stack, Title, Text, PasswordInput } from '@mantine/core';
+import { useDispatch } from 'react-redux';
 import { useForm } from '@mantine/form';
 import { IconLock, IconUser, IconLogin } from '@tabler/icons';
 
 import Success from '../../components/info/success';
 import { signIn } from '../../api/authentication';
 import { setToken } from '../../helpers/token';
+import { userLogin } from '../../actions';
 import config from '../../config';
 
 const Secret = () => {
-    const [token, setTokenState] = useState('');
     const [success, setSuccess] = useState(false);
+
+    const dispatch = useDispatch();
 
     const form = useForm({
         initialValues: {
@@ -42,7 +45,7 @@ const Secret = () => {
             return;
         }
 
-        setTokenState(data.token);
+        dispatch(userLogin(data.token));
         form.clearErrors();
         setSuccess(true);
     };

--- a/src/client/routes/signup/index.js
+++ b/src/client/routes/signup/index.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { Redirect } from 'react-router-dom';
 import { Button, Container, TextInput, Stack, Title, Text, PasswordInput } from '@mantine/core';
+import { useDispatch, useSelector } from 'react-redux';
 import { useForm } from '@mantine/form';
 import { IconLock, IconUser, IconLogin, IconAt } from '@tabler/icons';
 
@@ -10,8 +11,10 @@ import { setToken } from '../../helpers/token';
 import config from '../../config';
 
 const Secret = () => {
-    const [token, setTokenState] = useState('');
     const [success, setSuccess] = useState(false);
+
+    const dispatch = useDispatch();
+    const token = useSelector((state) => state.token);
 
     const form = useForm({
         initialValues: {
@@ -43,7 +46,7 @@ const Secret = () => {
             return;
         }
 
-        setTokenState(data.token);
+        dispatch(userLogin(data.token));
         form.clearErrors();
         setSuccess(true);
     };

--- a/src/client/util/constants.js
+++ b/src/client/util/constants.js
@@ -1,0 +1,2 @@
+export const USER_LOGIN_CHANGED = 'USER_LOGIN_CHANGED';
+export const USER_LOGIN = 'USER_LOGIN';


### PR DESCRIPTION
feat: leverage redux store to preserve the token on userLogin action) instead of having component level state

## Description
<!--- Describe your changes in detail -->

Previously, the login token was handled in the component level state on sign-in and sign-up which was repeated logic and also the sign-in/sign-out has less flexibility due to the component level state. Now, the token is stored in the global redux store on sign-up/sign-in actions and users can be logged out from anywhere else within the application

## Related Issue
Fix #107 
