### PR TITLE
Fix for issue #125 Multiple users are able to sign up with the same email

### DIFF
--- a/src/client/routes/signup/index.js
+++ b/src/client/routes/signup/index.js
@@ -9,6 +9,7 @@ import Success from '../../components/info/success';
 import { signUp } from '../../api/authentication';
 import { setToken } from '../../helpers/token';
 import config from '../../config';
+import { userLogin } from '../../actions';
 
 const Secret = () => {
     const [success, setSuccess] = useState(false);

--- a/src/server/controllers/authentication.js
+++ b/src/server/controllers/authentication.js
@@ -45,6 +45,13 @@ async function authentication(fastify) {
                     .send({ type: 'username', error: `This username has already been taken.` });
             }
 
+            const users = await redis.getAllUsers();
+            if (users.filter((user) => user && user.email === email).length > 0) {
+                return reply
+                    .code(403)
+                    .send({ type: 'email', error: `This email has already been registered.` });
+            }
+
             const userPassword = await hash(validator.escape(password));
 
             const user = await redis.createUser(username, email, userPassword);

--- a/src/server/services/redis.js
+++ b/src/server/services/redis.js
@@ -134,7 +134,7 @@ export async function getAllUsers() {
 }
 
 export async function getAllUserNames() {
-    const keys = await client.keys('*');
+    const keys = await client.keys('user:*');
     return keys.map((key) => key.split(':')[1]);
 }
 

--- a/src/server/services/redis.js
+++ b/src/server/services/redis.js
@@ -128,6 +128,16 @@ export async function getUser(username) {
     return client.hgetall(`user:${username}`);
 }
 
+export async function getAllUsers() {
+    const usernames = await getAllUserNames();
+    return Promise.all(usernames.map(async (username) => await client.hgetall(`user:${username}`)));
+}
+
+export async function getAllUserNames() {
+    const keys = await client.keys('*');
+    return keys.map((key) => key.split(':')[1]);
+}
+
 export async function deleteUser(username) {
     return client.del(`user:${username}`);
 }


### PR DESCRIPTION
fix: prevent multiple users from registering via the same email id

## Description
<!--- Describe your changes in detail -->

Previously multiple users could use the same email address to sign up. With this fix, an email can only be associated to a single user

## Related Issue
Fix #125 