### PR TITLE
feat: support fig complete

### DIFF
--- a/hemmelig.ts
+++ b/hemmelig.ts
@@ -1,0 +1,82 @@
+const completionSpec: Fig.Spec = {
+    "name": "hemmelig",
+    "description": "Encrypt text",
+    "args": [
+        {
+            "name": "text",
+            "description": "Text"
+        }
+    ],
+    "options": [
+        {
+            "name": ["-t", "--title"],
+            "description": "The secret title",
+            "isOptional": true,
+            "args": {
+                "name": "title",
+                "description": "The secret title"
+            }
+        },
+        {
+            "name": ["-p", "--password"],
+            "description": "The password to protect the secret",
+            "isOptional": true,
+            "args": {
+                "name": "password",
+                "description": "The password to protect the secret"
+            }
+        },
+        {
+            "name": ["-l", "--lifetime"],
+            "description": "The lifetime of the secret",
+            "isOptional": true,
+            "args": {
+                "name": "lifetime",
+                "description": "The lifetime of the secret"
+            }
+        },
+        {
+            "name": ["-m", "--maxViews"],
+            "description": "The max views of the secret",
+            "isOptional": true,
+            "args": {
+                "name": "maxViews",
+                "description": "The max views of the secret"
+            }
+        },
+        {
+            "name": ["-c", "--cidr"],
+            "description": "Provide the IP or CIDR range",
+            "isOptional": true,
+            "args": {
+                "name": "cidr",
+                "description": "Provide the IP or CIDR range"
+            }
+        },
+        {
+            "name": ["-e", "--expire"],
+            "description": "Burn the secret only after the expire time",
+            "isOptional": true,
+            "args": {
+                "name": "expire",
+                "description": "Burn the secret only after the expire time"
+            }
+        },
+        {
+            "name": ["-u", "--url"],
+            "description": "If you have your own instance of the Hemmelig.app",
+            "isOptional": true,
+            "args": {
+                "name": "url",
+                "description": "If you have your own instance of the Hemmelig.app"
+            }
+        },
+        {
+            "name": "--help",
+            "description": "Prints help information",
+            "isOptional": true,
+        }
+    ]
+    
+};
+export default completionSpec;


### PR DESCRIPTION
Support [Fig](https://fig.io/)'s command line auto-completion, the effect is as follows: 
![1](https://user-images.githubusercontent.com/29839231/212111303-24488445-2d4d-43be-96a4-04e04c2ccf20.png)

Configuration method: 
```shell 
npx @fig/publish-spec --spec-path complete/fig/hemmelig.ts --name hemmelig 
```