### PR TITLE
Updating build actions to include ARM architecture

### DIFF
--- a/.github/workflows/publish_bleeding_edge_docker.yaml
+++ b/.github/workflows/publish_bleeding_edge_docker.yaml
@@ -11,7 +11,13 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Check out the repo
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
+            # Workaround: https://github.com/docker/build-push-action/issues/461
+            - name: Setup Docker buildx
+              uses: docker/setup-buildx-action@v2.4.1
+            - name: Set up QEMU
+              uses: docker/setup-qemu-action@v2.1.0
+
             - name: Log in to Docker Hub
               uses: docker/login-action@v1
               with:
@@ -19,7 +25,8 @@ jobs:
                   password: ${{ secrets.DOCKER_PASSWORD }}
 
             - name: Push to Docker Hub
-              uses: docker/build-push-action@v2
+              uses: docker/build-push-action@v4
               with:
+                  platforms: linux/amd64,linux/arm64,linux/arm/v7
                   push: true
                   tags: hemmeligapp/hemmelig:bleeding-edge

--- a/.github/workflows/publish_daily_docker.yaml
+++ b/.github/workflows/publish_daily_docker.yaml
@@ -10,7 +10,13 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Check out the repo
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
+            # Workaround: https://github.com/docker/build-push-action/issues/461
+            - name: Setup Docker buildx
+              uses: docker/setup-buildx-action@v2.4.1
+            - name: Set up QEMU
+              uses: docker/setup-qemu-action@v2.1.0
+
             - name: Log in to Docker Hub
               uses: docker/login-action@v1
               with:
@@ -18,7 +24,8 @@ jobs:
                   password: ${{ secrets.DOCKER_PASSWORD }}
 
             - name: Push to Docker Hub
-              uses: docker/build-push-action@v2
+              uses: docker/build-push-action@v4
               with:
+                  platforms: linux/amd64,linux/arm64,linux/arm/v7
                   push: true
                   tags: hemmeligapp/hemmelig:daily

--- a/.github/workflows/publish_docker_image.yaml
+++ b/.github/workflows/publish_docker_image.yaml
@@ -8,7 +8,13 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Check out the repo
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
+            # Workaround: https://github.com/docker/build-push-action/issues/461
+            - name: Setup Docker buildx
+              uses: docker/setup-buildx-action@v2.4.1
+            - name: Set up QEMU
+              uses: docker/setup-qemu-action@v2.1.0
+
             - name: Log in to Docker Hub
               uses: docker/login-action@v1
               with:
@@ -20,12 +26,14 @@ jobs:
               with:
                   fallback: no-tag
             - name: Push to Docker Hub
-              uses: docker/build-push-action@v2
+              uses: docker/build-push-action@v4
               with:
+                  platforms: linux/amd64,linux/arm64,linux/arm/v7
                   push: true
                   tags: hemmeligapp/hemmelig:latest
             - name: Push to Docker Hub
-              uses: docker/build-push-action@v2
+              uses: docker/build-push-action@v4
               with:
+                  platforms: linux/amd64,linux/arm64,linux/arm/v7
                   push: true
                   tags: hemmeligapp/hemmelig:${{ steps.latest_tag.outputs.tag }}

--- a/.github/workflows/publish_weekly_docker.yaml
+++ b/.github/workflows/publish_weekly_docker.yaml
@@ -11,6 +11,12 @@ jobs:
         steps:
             - name: Check out the repo
               uses: actions/checkout@v2
+            # Workaround: https://github.com/docker/build-push-action/issues/461
+            - name: Setup Docker buildx
+              uses: docker/setup-buildx-action@v2.4.1
+            - name: Set up QEMU
+              uses: docker/setup-qemu-action@v2.1.0
+
             - name: Log in to Docker Hub
               uses: docker/login-action@v1
               with:
@@ -18,7 +24,8 @@ jobs:
                   password: ${{ secrets.DOCKER_PASSWORD }}
 
             - name: Push to Docker Hub
-              uses: docker/build-push-action@v2
+              uses: docker/build-push-action@v4
               with:
+                  platforms: linux/amd64,linux/arm64,linux/arm/v7
                   push: true
                   tags: hemmeligapp/hemmelig:weekly


### PR DESCRIPTION
Added QEMU and Buildx to the docker build, and updated the actions to later versions
These changes havent entirely been tested, I made a manual workflow push for a different tag but should work all the same
Havent made any changes to `trivy.yaml`, im not sure how this one runs and am unsure how to modify and keep its operation the same