### PR TITLE
fix: allow redis.user to be optional for AUTH

### DIFF
--- a/src/server/services/redis.js
+++ b/src/server/services/redis.js
@@ -10,7 +10,7 @@ const options = {
     tls: config.get('redis.tls'),
 };
 
-if (config.get('redis.user', null) && config.get('redis.password', null)) {
+if (config.get('redis.password', null)) {
     Object.assign(options, {
         user: config.get('redis.user', null),
         password: config.get('redis.password', null),


### PR DESCRIPTION
When using Hemmelig.app with the bitnami redis chart, the auth mechanism only works when providing just the password, no username required. This PR removes the `redis.user` check when creating the options object to pass to asyncRedis.createClient.