### PR TITLE
fixed duplicated terms option in mobile view

### DIFF
--- a/src/client/components/header/nav.jsx
+++ b/src/client/components/header/nav.jsx
@@ -63,13 +63,6 @@ const Nav = ({ opened, toggle, isLoggedIn }) => {
             onClick: toggle,
             to: '/terms',
         });
-        navItems.push({
-            label: 'Terms & Condition',
-            icon: <IconList size="1rem" stroke={1.5} />,
-            component: Link,
-            onClick: toggle,
-            to: '/terms',
-        });
     }
 
     if (!opened) {


### PR DESCRIPTION
fixes #224 
removed the duplicated code for the 'Terms & Condition' nav item in mobile view