### PR TITLE
fix: default ttl set to 72 hours on reset

### DIFF
--- a/src/client/routes/home/index.jsx
+++ b/src/client/routes/home/index.jsx
@@ -121,7 +121,7 @@ const Home = () => {
         setOnEnablePassword(false);
         setCreatingSecret(false);
         setText('');
-        setTTL(14400);
+        setTTL(DEFAULT_TTL);
         setError('');
     };
 


### PR DESCRIPTION
fixes #227 
replaced the 3 hours ttl with 72 hours (default ttl) on reset