### PR TITLE
fix: top view visibility in lifetime select component

### DIFF
--- a/src/client/routes/home/index.jsx
+++ b/src/client/routes/home/index.jsx
@@ -302,6 +302,7 @@ const Home = () => {
 
                     <Group grow>
                         <Select
+                            zIndex={9999}
                             value={ttl}
                             onChange={onSelectChange}
                             data={ttlValues}


### PR DESCRIPTION
fixes #229 
Increased the z-index for the lifetime select component to be more than the Quill component's z-index (1000)