### PR TITLE
refactor: use react router loader to fetch data to eliminate the use of useEffect

### DIFF
--- a/src/client/routes.jsx
+++ b/src/client/routes.jsx
@@ -87,7 +87,15 @@ const appRouter = createBrowserRouter(
                         return await getSettings();
                     }}
                 />
-                <Route path="account-settings" element={<UserAccount />} />
+                <Route
+                    path="account-settings"
+                    element={<UserAccount />}
+                    loader={async () => {
+                        const { getUser } = await import('./api/account');
+
+                        return await getUser();
+                    }}
+                />
                 <Route
                     path="users"
                     element={<Users />}

--- a/src/client/routes.jsx
+++ b/src/client/routes.jsx
@@ -78,7 +78,15 @@ const appRouter = createBrowserRouter(
                         return await getSecrets();
                     }}
                 />
-                <Route path="instance-settings" element={<Settings />} />
+                <Route
+                    path="instance-settings"
+                    element={<Settings />}
+                    loader={async () => {
+                        const { getSettings } = await import('./api/settings');
+
+                        return await getSettings();
+                    }}
+                />
                 <Route path="account-settings" element={<UserAccount />} />
                 <Route path="users" element={<Users />} />
                 <Route path="privacy" element={<Privacy />} />

--- a/src/client/routes.jsx
+++ b/src/client/routes.jsx
@@ -69,7 +69,15 @@ const appRouter = createBrowserRouter(
                         return await getUser();
                     }}
                 />
-                <Route path="secrets" element={<Secrets />} />
+                <Route
+                    path="secrets"
+                    element={<Secrets />}
+                    loader={async () => {
+                        const { getSecrets } = await import('./api/secret');
+
+                        return await getSecrets();
+                    }}
+                />
                 <Route path="instance-settings" element={<Settings />} />
                 <Route path="account-settings" element={<UserAccount />} />
                 <Route path="users" element={<Users />} />

--- a/src/client/routes.jsx
+++ b/src/client/routes.jsx
@@ -88,7 +88,15 @@ const appRouter = createBrowserRouter(
                     }}
                 />
                 <Route path="account-settings" element={<UserAccount />} />
-                <Route path="users" element={<Users />} />
+                <Route
+                    path="users"
+                    element={<Users />}
+                    loader={async () => {
+                        const { getUsers } = await import('./api/users');
+
+                        return await getUsers();
+                    }}
+                />
                 <Route path="privacy" element={<Privacy />} />
                 <Route path="terms" element={<Terms />} />
             </Route>

--- a/src/client/routes.jsx
+++ b/src/client/routes.jsx
@@ -51,8 +51,24 @@ const appRouter = createBrowserRouter(
                 <Route path="terms" element={<Terms />} />
             </Route>
             <Route path="/account" element={<AdminShell />}>
-                <Route index element={<Account />} />
-                <Route path="account" element={<Account />} />
+                <Route
+                    index
+                    element={<Account />}
+                    loader={async () => {
+                        const { getUser } = await import('./api/account');
+
+                        return await getUser();
+                    }}
+                />
+                <Route
+                    path="account"
+                    element={<Account />}
+                    loader={async () => {
+                        const { getUser } = await import('./api/account');
+
+                        return await getUser();
+                    }}
+                />
                 <Route path="secrets" element={<Secrets />} />
                 <Route path="instance-settings" element={<Settings />} />
                 <Route path="account-settings" element={<UserAccount />} />

--- a/src/client/routes/account/account.jsx
+++ b/src/client/routes/account/account.jsx
@@ -78,7 +78,6 @@ const Account = () => {
                     updatedUserInfo.message
                         ? updatedUserInfo.message
                         : t('account.account.can_not_update_profile')
-
                 );
 
                 return;

--- a/src/client/routes/account/account.jsx
+++ b/src/client/routes/account/account.jsx
@@ -1,69 +1,34 @@
-import {
-    Button,
-    Container,
-    Group,
-    Loader,
-    PasswordInput,
-    Stack,
-    Text,
-    TextInput,
-} from '@mantine/core';
+import { Button, Group, PasswordInput, Stack, Text, TextInput } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { openConfirmModal } from '@mantine/modals';
 import { IconAt, IconEdit, IconLock, IconTrash } from '@tabler/icons';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Navigate } from 'react-router-dom';
+import { Navigate, useLoaderData } from 'react-router-dom';
 import ErrorBox from '../../components/error-box';
 import SuccessBox from '../../components/success-box';
 
 import style from './account.module.css';
 
-import { deleteUser, getUser, updateUser } from '../../api/account';
+import { deleteUser, updateUser } from '../../api/account';
 
 const Account = () => {
     const [success, setSuccess] = useState(false);
     const [error, setError] = useState(null);
-    const [isLoading, setIsLoading] = useState(true);
-    const [userError, setUserError] = useState(null);
     const [successMessage, setSuccessMessage] = useState(null);
     const [deleted, setDeleted] = useState(false);
 
     const { t } = useTranslation();
 
+    const userInfo = useLoaderData();
+
     const form = useForm({
-        initialValues: {
-            currentPassword: '',
-            newPassword: '',
-            email: '',
-            confirmNewPassword: '',
-        },
+        initialValues: userInfo?.user,
         validate: {
             confirmNewPassword: (value, values) =>
                 value !== values.newPassword ? t('account.account.passwords_does_not_match') : null,
         },
     });
-
-    useEffect(() => {
-        (async () => {
-            try {
-                const userInfo = await getUser();
-
-                if (userInfo.error || [401, 500].includes(userInfo.statusCode)) {
-                    setUserError(userInfo.error ? userInfo.error : t('not_logged_in'));
-
-                    return;
-                }
-
-                form.setValues(userInfo.user);
-
-                setIsLoading(false);
-                setUserError(null);
-            } catch (err) {
-                setUserError(err);
-            }
-        })();
-    }, []);
 
     const onProfileUpdate = async (e) => {
         e.preventDefault();
@@ -151,15 +116,9 @@ const Account = () => {
         return <Navigate to="/signout" />;
     }
 
-    if (isLoading && !userError) {
-        return (
-            <Container>
-                <Loader color="teal" variant="bars" />
-            </Container>
-        );
-    }
+    if (userInfo.error || [401, 500].includes(userInfo.statusCode)) {
+        const userError = userInfo.error ? userInfo.error : t('not_logged_in');
 
-    if (userError) {
         return (
             <Stack>
                 <ErrorBox message={userError} />

--- a/src/client/routes/account/index.jsx
+++ b/src/client/routes/account/index.jsx
@@ -1,40 +1,26 @@
 import { Container, Loader, Stack, Text } from '@mantine/core';
-import { useEffect, useState } from 'react';
-import { Navigate } from 'react-router-dom';
+import { useState } from 'react';
+import { Navigate, useLoaderData } from 'react-router-dom';
 import ErrorBox from '../../components/error-box';
 
 import { useTranslation } from 'react-i18next';
-import { getUser } from '../../api/account';
 
 const HomeAccount = () => {
     const { t } = useTranslation();
 
-    const [user, setUser] = useState(null);
+    const userInfo = useLoaderData();
+
     const [error, setError] = useState(null);
-    const [isLoading, setIsLoading] = useState(true);
 
-    useEffect(() => {
-        (async () => {
-            try {
-                const userInfo = await getUser();
+    if (userInfo.error || [401, 500].includes(userInfo.statusCode)) {
+        setError(userInfo.error ? userInfo.error : t('not_logged_in'));
 
-                if (userInfo.error || [401, 500].includes(userInfo.statusCode)) {
-                    setError(userInfo.error ? userInfo.error : t('not_logged_in'));
+        return;
+    }
 
-                    return;
-                }
+    const { user = {} } = userInfo;
 
-                setUser(userInfo.user);
-
-                setIsLoading(false);
-                setError(null);
-            } catch (err) {
-                setError(err);
-            }
-        })();
-    }, []);
-
-    if (!user?.username && !isLoading) {
+    if (!user?.username) {
         return <Navigate replace to="/signin" />;
     }
 

--- a/src/client/routes/account/index.jsx
+++ b/src/client/routes/account/index.jsx
@@ -1,5 +1,4 @@
 import { Container, Loader, Stack, Text } from '@mantine/core';
-import { useState } from 'react';
 import { Navigate, useLoaderData } from 'react-router-dom';
 import ErrorBox from '../../components/error-box';
 
@@ -10,12 +9,12 @@ const HomeAccount = () => {
 
     const userInfo = useLoaderData();
 
-    const [error, setError] = useState(null);
-
-    if (userInfo.error || [401, 500].includes(userInfo.statusCode)) {
-        setError(userInfo.error ? userInfo.error : t('not_logged_in'));
-
-        return;
+    if (userInfo?.error || [401, 500].includes(userInfo.statusCode)) {
+        return (
+            <Stack>
+                <ErrorBox message={userInfo.error ? userInfo.error : t('not_logged_in')} />
+            </Stack>
+        );
     }
 
     const { user = {} } = userInfo;
@@ -29,14 +28,6 @@ const HomeAccount = () => {
             <Container>
                 <Loader color="teal" variant="bars" />
             </Container>
-        );
-    }
-
-    if (error) {
-        return (
-            <Stack>
-                <ErrorBox message={error} />
-            </Stack>
         );
     }
 

--- a/src/client/routes/account/secrets.jsx
+++ b/src/client/routes/account/secrets.jsx
@@ -51,8 +51,6 @@ const Secrets = () => {
                 <ErrorBox message={error} />
             </Stack>
         );
-
-        return;
     }
 
     const onDeleteSecret = async (secret) => {

--- a/src/client/routes/account/settings.jsx
+++ b/src/client/routes/account/settings.jsx
@@ -12,8 +12,6 @@ import { updateSettings } from '../../api/settings';
 const Settings = () => {
     const [success, setSuccess] = useState(false);
     const [error, setError] = useState(null);
-    const [isLoading, setIsLoading] = useState(true);
-    const [userError, setUserError] = useState(null);
 
     const { t } = useTranslation();
 

--- a/src/client/routes/account/settings.jsx
+++ b/src/client/routes/account/settings.jsx
@@ -1,12 +1,13 @@
-import { Button, Checkbox, Container, Group, Input, Loader, Stack, Text } from '@mantine/core';
+import { Button, Checkbox, Group, Input, Stack, Text } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { IconAt, IconEdit } from '@tabler/icons';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useLoaderData } from 'react-router-dom';
 import ErrorBox from '../../components/error-box';
 import SuccessBox from '../../components/success-box';
 
-import { getSettings, updateSettings } from '../../api/settings';
+import { updateSettings } from '../../api/settings';
 
 const Settings = () => {
     const [success, setSuccess] = useState(false);
@@ -16,36 +17,11 @@ const Settings = () => {
 
     const { t } = useTranslation();
 
+    const adminSettings = useLoaderData();
+
     const form = useForm({
-        initialValues: {
-            read_only: false,
-            disable_users: false,
-            disable_user_account_creation: false,
-            disable_file_upload: false,
-            restrict_organization_email: '',
-        },
+        initialValues: adminSettings,
     });
-
-    useEffect(() => {
-        (async () => {
-            try {
-                const adminSettings = await getSettings();
-
-                if (adminSettings.error || [401, 403, 500].includes(adminSettings.statusCode)) {
-                    setUserError(adminSettings.error ? adminSettings.error : t('not_logged_in'));
-
-                    return;
-                }
-
-                form.setValues(adminSettings[0]);
-
-                setIsLoading(false);
-                setUserError(null);
-            } catch (err) {
-                setUserError(err);
-            }
-        })();
-    }, []);
 
     const onUpdateSettings = async (e) => {
         e.preventDefault();
@@ -79,18 +55,12 @@ const Settings = () => {
         }
     };
 
-    if (isLoading && !userError) {
-        return (
-            <Container>
-                <Loader color="teal" variant="bars" />
-            </Container>
-        );
-    }
+    if (adminSettings.error || [401, 403, 500].includes(adminSettings.statusCode)) {
+        const error = adminSettings.error ? adminSettings.error : t('not_logged_in');
 
-    if (userError) {
         return (
             <Stack>
-                <ErrorBox message={userError} />
+                <ErrorBox message={error} />
             </Stack>
         );
     }

--- a/src/client/routes/account/users.jsx
+++ b/src/client/routes/account/users.jsx
@@ -85,8 +85,6 @@ const Users = () => {
     const [success, setSuccess] = useState(false);
     const [error, setError] = useState(null);
     const [opened, { open, close }] = useDisclosure(false);
-    const [isLoading, setIsLoading] = useState(true);
-    const [userError, setUserError] = useState(null);
 
     const { t } = useTranslation();
 

--- a/src/client/routes/account/users.jsx
+++ b/src/client/routes/account/users.jsx
@@ -4,7 +4,6 @@ import {
     Center,
     Container,
     Group,
-    Loader,
     Modal,
     PasswordInput,
     Select,
@@ -17,8 +16,9 @@ import { useForm } from '@mantine/form';
 import { useDisclosure } from '@mantine/hooks';
 import { openConfirmModal } from '@mantine/modals';
 import { IconAt, IconChefHat, IconEdit, IconPlus, IconTrash, IconUser } from '@tabler/icons';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useLoaderData } from 'react-router-dom';
 
 import { addUser, deleteUser, getUsers, updateUser } from '../../api/users';
 import ErrorBox from '../../components/error-box';
@@ -50,9 +50,36 @@ const addUserList = (users, data) => {
     return updated;
 };
 
+const UserRows = ({ users, open, form, setModalState, openDeleteModal }) => {
+    return users.map((user) => (
+        <tr key={user.username}>
+            <td>{user.username}</td>
+            <td>{user.email}</td>
+            <td>{user.role}</td>
+            <td>
+                <ActionIcon
+                    variant="filled"
+                    onClick={(event) => {
+                        open(event);
+                        form.setValues(user);
+                        setModalState('update');
+                    }}
+                >
+                    <IconEdit size="1rem" />
+                </ActionIcon>
+            </td>
+            <td>
+                <ActionIcon variant="filled" onClick={() => openDeleteModal(user)}>
+                    <IconTrash size="1rem" />
+                </ActionIcon>
+            </td>
+        </tr>
+    ));
+};
+
 const Users = () => {
     const [modalState, setModalState] = useState('add');
-    const [users, setUsers] = useState([]);
+    const [users, setUsers] = useState(useLoaderData());
     const [skip, setSkip] = useState(SKIP);
     const [showMore, setShowMore] = useState(true);
     const [success, setSuccess] = useState(false);
@@ -66,40 +93,17 @@ const Users = () => {
     const defaultValues = {
         username: '',
         email: '',
-        role: '',
+        role: 'user',
         password: '',
     };
 
     const form = useForm({
-        initialValues: defaultValues,
+        initialValues: users,
     });
 
-    useEffect(() => {
-        (async () => {
-            try {
-                const users = await getUsers();
-
-                if (users.error || [401, 403, 500].includes(users.statusCode)) {
-                    setUserError(users.error ? users.error : t('not_logged_in'));
-
-                    return;
-                }
-
-                if (users?.length < SKIP) {
-                    setShowMore(false);
-                }
-
-                if (!users?.error) {
-                    setUsers(users);
-                }
-
-                setIsLoading(false);
-                setUserError(null);
-            } catch (err) {
-                setUserError(err);
-            }
-        })();
-    }, []);
+    if (users?.length < SKIP) {
+        setShowMore(false);
+    }
 
     const onUpdateUser = async (event) => {
         event.preventDefault();
@@ -224,40 +228,9 @@ const Users = () => {
         close(event);
     };
 
-    const rows = users.map((user) => (
-        <tr key={user.username}>
-            <td>{user.username}</td>
-            <td>{user.email}</td>
-            <td>{user.role}</td>
-            <td>
-                <ActionIcon
-                    variant="filled"
-                    onClick={(event) => {
-                        open(event);
-                        form.setValues(user);
-                        setModalState('update');
-                    }}
-                >
-                    <IconEdit size="1rem" />
-                </ActionIcon>
-            </td>
-            <td>
-                <ActionIcon variant="filled" onClick={() => openDeleteModal(user)}>
-                    <IconTrash size="1rem" />
-                </ActionIcon>
-            </td>
-        </tr>
-    ));
+    if (users.error || [401, 403, 500].includes(users?.statusCode)) {
+        const userError = users.error ? users.error : t('not_logged_in');
 
-    if (isLoading && !userError) {
-        return (
-            <Container>
-                <Loader color="teal" variant="bars" />
-            </Container>
-        );
-    }
-
-    if (userError) {
         return (
             <Stack>
                 <ErrorBox message={userError} />
@@ -340,7 +313,15 @@ const Users = () => {
                             <th>Delete</th>
                         </tr>
                     </thead>
-                    <tbody>{rows}</tbody>
+                    <tbody>
+                        <UserRows
+                            users={users}
+                            open={open}
+                            form={form}
+                            setModalState={setModalState}
+                            openDeleteModal={openDeleteModal}
+                        />
+                    </tbody>
                 </Table>
             </Group>
 

--- a/src/server/controllers/admin/settings.js
+++ b/src/server/controllers/admin/settings.js
@@ -9,7 +9,7 @@ async function settings(fastify) {
             preValidation: [fastify.authenticate, fastify.admin],
         },
         async () => {
-            const settings = await prisma.settings.findMany({
+            const settings = await prisma.settings.findFirst({
                 where: {
                     id: 'admin_settings',
                 },


### PR DESCRIPTION
This pull request includes major changes to the routing and data fetching in the client-side codebase, as well as a small change to the server-side settings controller. The changes mainly involve moving the data fetching logic from individual components to the router, and using the `useLoaderData` hook to access the fetched data in the components. This simplifies the components by removing unnecessary state and effect hooks related to data fetching, and centralizes the data fetching logic in the router.

Changes to the router:

* [`src/client/routes.jsx`](diffhunk://#diff-ed961310f253031d46d658d75af53de7475d9b1cd5bc0f5fa0db86285443f015L54-R107): Added a `loader` prop to each `Route` component under the `/account` path. Each loader is an asynchronous function that imports and calls the appropriate API function to fetch the necessary data for the route.

Changes to components:

* [`src/client/routes/account/account.jsx`](diffhunk://#diff-4bba43d340320be6a56098be3d1512fa5b9760daaf073d85c3f3697ba4b1f946L1-L67): Removed the `getUser` call and the associated state and effect hook. Now uses `useLoaderData` to get the user data. [[1]](diffhunk://#diff-4bba43d340320be6a56098be3d1512fa5b9760daaf073d85c3f3697ba4b1f946L1-L67) [[2]](diffhunk://#diff-4bba43d340320be6a56098be3d1512fa5b9760daaf073d85c3f3697ba4b1f946L81) [[3]](diffhunk://#diff-4bba43d340320be6a56098be3d1512fa5b9760daaf073d85c3f3697ba4b1f946L155-L163)
* [`src/client/routes/account/index.jsx`](diffhunk://#diff-8e19c6f5e8e5f77ed175d47def5065308967298fd05ee1609d8f691813ad9483L2-R22): Similar changes as `account.jsx`. [[1]](diffhunk://#diff-8e19c6f5e8e5f77ed175d47def5065308967298fd05ee1609d8f691813ad9483L2-R22) [[2]](diffhunk://#diff-8e19c6f5e8e5f77ed175d47def5065308967298fd05ee1609d8f691813ad9483L49-L56)
* [`src/client/routes/account/secrets.jsx`](diffhunk://#diff-b09d7265295e43385d7f6948a8ca781f4f72af71ae842036747e8b24186aa0b4L1-R13): Similar changes as `account.jsx`, but for fetching secrets. [[1]](diffhunk://#diff-b09d7265295e43385d7f6948a8ca781f4f72af71ae842036747e8b24186aa0b4L1-R13) [[2]](diffhunk://#diff-b09d7265295e43385d7f6948a8ca781f4f72af71ae842036747e8b24186aa0b4L31-R32) [[3]](diffhunk://#diff-b09d7265295e43385d7f6948a8ca781f4f72af71ae842036747e8b24186aa0b4L48-L67) [[4]](diffhunk://#diff-b09d7265295e43385d7f6948a8ca781f4f72af71ae842036747e8b24186aa0b4L124-L142)
* [`src/client/routes/account/settings.jsx`](diffhunk://#diff-15954b307546dd38f565440ca634a3cfa649fd8d0e1ac21ec1d1390967625176L1-L49): Similar changes as `account.jsx`, but for fetching settings. [[1]](diffhunk://#diff-15954b307546dd38f565440ca634a3cfa649fd8d0e1ac21ec1d1390967625176L1-L49) [[2]](diffhunk://#diff-15954b307546dd38f565440ca634a3cfa649fd8d0e1ac21ec1d1390967625176L82-R61)
* [`src/client/routes/account/users.jsx`](diffhunk://#diff-bdebe8cf121bb58ba61bb048589aeacda32db7236600c1e2fdc70412f8d3327eL7): Similar changes as `account.jsx`, but for fetching users. Also moved the user row rendering logic to a separate `UserRows` component. [[1]](diffhunk://#diff-bdebe8cf121bb58ba61bb048589aeacda32db7236600c1e2fdc70412f8d3327eL7) [[2]](diffhunk://#diff-bdebe8cf121bb58ba61bb048589aeacda32db7236600c1e2fdc70412f8d3327eL20-R21) [[3]](diffhunk://#diff-bdebe8cf121bb58ba61bb048589aeacda32db7236600c1e2fdc70412f8d3327eR53-R82) [[4]](diffhunk://#diff-bdebe8cf121bb58ba61bb048589aeacda32db7236600c1e2fdc70412f8d3327eL69-L103) [[5]](diffhunk://#diff-bdebe8cf121bb58ba61bb048589aeacda32db7236600c1e2fdc70412f8d3327eL227-L260) [[6]](diffhunk://#diff-bdebe8cf121bb58ba61bb048589aeacda32db7236600c1e2fdc70412f8d3327eL343-R324)

Change to server-side controller:

* [`src/server/controllers/admin/settings.js`](diffhunk://#diff-59ddd6051b4c8f4116b261bfe0998e5c1fffa4c15699625fd8c845066d4473ccL12-R12): Changed the `findMany` call to `findFirst` when fetching admin settings, as there should only be one set of admin settings.