### PR TITLE
fix: check show more before setting the state

### DIFF
--- a/client/routes/account/users.jsx
+++ b/client/routes/account/users.jsx
@@ -99,7 +99,7 @@ const Users = () => {
         initialValues: users,
     });
 
-    if (users?.length < SKIP) {
+    if (showMore && users?.length < SKIP) {
         setShowMore(false);
     }
 


### PR DESCRIPTION
by doing this we will prevent an endless loop

### copilot
This pull request includes a modification to the `Users` function in the `client/routes/account/users.jsx` file. The change adds a condition to check the `showMore` variable before executing the logic inside the `if` statement.

The most important change is:

* [`client/routes/account/users.jsx`](diffhunk://#diff-911627813cd727849adde33dd3ccb2d328b583753352b2df8ba561efcb75c2e9L102-R102): Added a condition to check the `showMore` variable in the `if` statement that checks if the length of the `users` array is less than `SKIP`. This modification ensures that the logic inside the `if` statement is executed only when `showMore` is true and the length of `users` is less than `SKIP`.