### PR TITLE
- Add missing translations to account/users & signin routes

### DIFF
--- a/client/routes/account/users.jsx
+++ b/client/routes/account/users.jsx
@@ -211,10 +211,10 @@ const Users = () => {
     const openDeleteModal = (user) => {
         setSuccess(false);
         openConfirmModal({
-            title: 'Delete ' + user.username,
+            title: "{t('account.users.delete')}" + " " + user.username,
             centered: true,
-            children: <Text size="sm">Are you sure you want to delete this user?</Text>,
-            labels: { confirm: 'Delete user', cancel: "No don't delete it" },
+            children: <Text size="sm">{t('account.users.do_you_want_delete')}</Text>,
+            labels: { confirm: "{t('account.users.delete_user')}", cancel: "{t('account.users.dont_delete_user')}" },
             confirmProps: { color: 'red' },
             onConfirm: () => onDeleteUser(user),
         });
@@ -239,7 +239,7 @@ const Users = () => {
     if (!users.length) {
         return (
             <Container size="xs ">
-                <ErrorBox message={'You have to be an admin to view the users'} />
+                <ErrorBox message="{t('account.users.have_to_be_admin')}" />
             </Container>
         );
     }
@@ -251,36 +251,36 @@ const Users = () => {
                 {success && <SuccessBox message={'users.saved'} />}
                 <Stack>
                     <TextInput
-                        label="Username"
+                        label="{t('account.users.username')}"
                         icon={<IconUser size={14} />}
-                        placeholder="Username"
+                        placeholder="{t('account.users.username')}"
                         disabled={modalState === 'update'}
                         {...form.getInputProps('username')}
                     />
                     <TextInput
-                        label="Email"
+                        label="{t('account.users.email')}"
                         icon={<IconAt size={14} />}
-                        placeholder="Email"
+                        placeholder="{t('account.users.email')}"
                         {...form.getInputProps('email')}
                     />
                     {modalState === 'add' && (
                         <PasswordInput
-                            label="Password"
+                            label="{t('account.users.password')}"
                             icon={<IconAt size={14} />}
-                            placeholder="Password"
+                            placeholder="{t('account.users.password')}"
                             {...form.getInputProps('password')}
                         />
                     )}
                     <Select
-                        label="Role"
-                        placeholder="Role"
+                        label="{t('account.users.role')}"
+                        placeholder="{t('account.users.role')}"
                         icon={<IconChefHat size={14} />}
                         value={form.getInputProps('role').value}
                         onChange={(value) => form.setFieldValue('role', value)}
                         data={[
-                            { value: 'admin', label: 'Admin' },
-                            { value: 'creator', label: 'Creator' },
-                            { value: 'user', label: 'User' },
+                            { value: "admin", label: "{t('account.users.admin')}" },
+                            { value: "creator", label: "{t('account.users.creator')}" },
+                            { value: "user", label: "{t('account.users.user')}" },
                         ]}
                     />
                 </Stack>
@@ -304,11 +304,11 @@ const Users = () => {
                 <Table horizontalSpacing="sm" highlightOnHover>
                     <thead>
                         <tr>
-                            <th>Username</th>
-                            <th>Email</th>
-                            <th>Role</th>
-                            <th>Edit</th>
-                            <th>Delete</th>
+                            <th>{t('account.users.username')}</th>
+                            <th>{t('account.users.email')}</th>
+                            <th>{t('account.users.role')}</th>
+                            <th>{t('users.edit')}</th>
+                            <th>{t('account.users.delete')}</th>
                         </tr>
                     </thead>
                     <tbody>

--- a/client/routes/signin/index.jsx
+++ b/client/routes/signin/index.jsx
@@ -31,8 +31,8 @@ const SignIn = () => {
 
         if (data.statusCode === 401) {
             form.setErrors({
-                username: 'Wrong username or password. Please try again.',
-                password: 'Wrong username or password. Please try again.',
+                username: "{t('signin.wrong_credentials')}",
+                password: "{t('signin.wrong_credentials')}",
             });
 
             setSuccess(false);

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -24,7 +24,6 @@
             "delete_account": "Delete your profile",
             "do_you_want_delete": "Are you sure you want to delete your profile?",
             "dont_delete_account": "No, don't delete it",
-
             "email": "Email",
             "your_password": "Current password",
             "current_password": "Your current password",
@@ -42,7 +41,7 @@
             "yes": "Yes",
             "no": "No",
             "delete_secret": "Delete secret",
-            "dont_delete_secret": "No don't delete it",
+            "dont_delete_secret": "No, don't delete it",
             "do_you_want_delete": "Are you sure you want to delete this secret?"
         },
         "settings": {
@@ -56,6 +55,20 @@
             "disable_file_upload_description": "Disable file upload for your instance",
             "restrict_organization_email": "Restrict to email domain",
             "restrict_organization_email_description": "This will limit user registration for a certain email domain"
+        },
+        "users": {
+            "username": "Username",
+            "email": "Email",
+            "password": "Password",
+            "role": "Role",
+            "admin": "Admin",
+            "creator": "Creator",
+            "user": "User",
+            "delete": "Delete",
+            "do_you_want_delete": "Are you sure you want to delete this user?",
+            "delete_user": "Delete user",
+            "dont_delete_user": "No, don't delete it",
+            "have_to_be_admin": "You have to be an admin to view the users"
         }
     },
     "public_list": "Public pastes",
@@ -163,7 +176,8 @@
         "heading": "Everything you need to access and manage the Hemmelig secrets.",
         "username": "Username",
         "password": "Your password",
-        "signin": "Sign in"
+        "signin": "Sign in",
+        "wrong_credentials": "Wrong username or password. Please try again."
     },
     "signup": {
         "title": "Sign up",

--- a/public/locales/nl/translation.json
+++ b/public/locales/nl/translation.json
@@ -13,26 +13,25 @@
             "hi": "Welkom",
             "intro": "Voor ingelogde gebruikers zijn er de volgende extra mogelijkheden",
             "upload_files": "Bestanden uploaden",
-            "expiration": "Een verlooptijd van 14 of 28 dagen voor geheimen",
+            "expiration": "Een verlooptijd voor geheimen van 14 of 28 dagen",
             "secrets": "Het bekijken en verwijderen van je geheimen",
-            "more": "Meer functies zullen latet worden toegevoegd! Bedankt voor je deelname aan Hemmelig.app!"
+            "more": "Meer functies zullen later worden toegevoegd! Fijn dat je Hemmelig.app gebruikt!"
         },
         "account": {
             "passwords_does_not_match": "Wachtwoorden komen niet overeen",
             "can_not_update_profile": "Je account kon niet worden bijgewerkt",
             "can_not_delete": "De account kon niet worden verwijderd",
-            "delete_account": "Account verwijderen",
+            "delete_account": "Verwijderen",
             "do_you_want_delete": "Weet je zeker dat je deze account wilt verwijderen?",
             "dont_delete_account": "Annuleren",
-
             "email": "E-mail",
             "your_password": "Huidig wachtwoord",
             "current_password": "Je huidige wachtwoord",
-            "update_your_password": "Wachtwoord bijwerken",
+            "update_your_password": "Wachtwoord veranderen",
             "new_password": "Nieuw wachtwoord",
             "confirm_password": "Wachtwoord bevestigen",
             "confirm_new_password": "Bevestig je nieuwe wachtwoord",
-            "update_details": "Bijwerken"
+            "update_details": "Opslaan"
         },
         "secrets": {
             "id": "Id",
@@ -43,7 +42,7 @@
             "no": "Nee",
             "delete_secret": "Geheim verwijderen",
             "dont_delete_secret": "Annuleren",
-            "do_you_want_delete": "Dit geheim verwijderen?"
+            "do_you_want_delete": "Weet je zeker dat je dit geheim wilt verwijderen?"
         },
         "settings": {
             "read_only_mode": "Alleen-lezenmodus",
@@ -53,9 +52,24 @@
             "disable_user_account_creation": "Accounts aanmaken niet toestaan",
             "disable_user_account_creation_description": "Schakel het aanmaken van nieuwe accounts uit. Als beheerder kun je nog steeds nieuwe accounts aanmaken.",
             "disable_file_upload": "Uploaden niet toestaan",
-            "disable_file_upload_description": "Schakel het uploaden van bestanden uit",
+            "disable_file_upload_description": "Schakel het uploaden van bestanden uit.",
             "restrict_organization_email": "E-mailadressen tot een domein beperken",
             "restrict_organization_email_description": "Beperk de registratie van accounts tot een enkel domein"
+        },
+        "users": {
+            "username": "Gebruikersnaam",
+            "email": "E-mail",
+            "password": "Wachtwoord",
+            "role": "Rol",
+            "admin": "Beheerder",
+            "creator": "Maker",
+            "user": "Gebruiker",
+            "delete": "Verwijderen",
+            "do_you_want_delete": "Weet je zeker dat je deze gebruiker wilt verwijderen?",
+            "delete_user": "Verwijderen",
+            "dont_delete_user": "Annuleren",
+            "deleted": "Gebruiker verwijderd",
+            "have_to_be_admin": "Je moet een beheerder zijn om de lijst met gebruikers te kunnen inzien"
         }
     },
     "public_list": "Publieke uitwisselingen",
@@ -128,13 +142,13 @@
     "settings": {
         "success": "Geslaagd",
         "description": "Instellingen van deze Hemmelig-installatie",
-        "updated": "Instellingen bijgewerkt",
-        "update": "Bijwerken",
+        "updated": "Instellingen opgeslagen",
+        "update": "Opslaan",
         "deleted": "Account verwijderd"
     },
     "users": {
         "users": "Gebruikers",
-        "edit": "Wijzigen",
+        "edit": "Bewerken",
         "update": "Bijwerken",
         "add": "Toevoegen",
         "saved": "Opgeslagen",
@@ -163,7 +177,8 @@
         "heading": "Alles om je geheimen te benaderen en te beheren.",
         "username": "Gebruikersnaam",
         "password": "Wachtwoord",
-        "signup": "Aanmelden"
+        "signin": "Inloggen",
+        "wrong_credentials": "Gebruikersnaam of wachtwoord onjuist. Probeer het opnieuw."
     },
     "signup": {
         "title": "Registreren",


### PR DESCRIPTION
- Fix signin.signin in English & Dutch

Supersedes #281

**I haven't built the project with these changes, so it needs testing.**

### Notes
1. I have inferred the proper use of quotes and double quotes from the rest of the code, but haven't built the app, so this needs to be double-checked.
1. I've used the new structure in the translation files to mirror the routes (e.g. `admin.users.role`), but a lot of the old strings that are used only under e.g. `admin.users` are still in `users`. I suppose this is easier to refactor in your IDE than it is for me to do this manually.