### PR TITLE
fix: Show maxViews after decrypting secret

### DIFF
--- a/client/routes/secret/index.jsx
+++ b/client/routes/secret/index.jsx
@@ -46,7 +46,7 @@ const Secret = () => {
     // Fetch secret existence on mount
     useEffect(() => {
         (async () => {
-            const response = await secretExists(secretId, password);
+            const response = await secretExists(secretId);
             if (response.statusCode === 401) {
                 setIsPasswordRequired(true);
                 return;
@@ -100,6 +100,8 @@ const Secret = () => {
                     );
                 }
 
+                setMaxViews(json.maxViews);
+
                 if (json.files) {
                     setFiles(json.files);
                 }
@@ -150,10 +152,10 @@ const Secret = () => {
                         {t('secret.view_your_secret')}
                     </h1>
                     <p className="text-base text-gray-400">{t('secret.will_show_once')}</p>
-                    {maxViews > 1 && (
+                    {maxViews > 0 && !preventBurn && (
                         <p className="text-base text-gray-400">
                             {t('secret.views_left')}{' '}
-                            <strong className="text-white">{maxViews}</strong>
+                            <strong className="text-white">{maxViews - 1}</strong>
                         </p>
                     )}
                 </div>

--- a/server/controllers/secret.js
+++ b/server/controllers/secret.js
@@ -71,6 +71,7 @@ async function getSecretRoute(request, reply) {
     return {
         title: data.title,
         preventBurn: data.preventBurn,
+        maxViews: data.maxViews,
         secret: data.data,
         files: data.files,
         isPublic: data.isPublic,
@@ -111,7 +112,9 @@ async function secret(fastify) {
             return reply.code(200).send(
                 secrets.map((secret) => ({
                     id: secret.id,
+                    preventBurn: secret.preventBurn,
                     expiresAt: secret.expiresAt,
+                    maxViews: secret.maxViews,
                     isPublic: secret.isPublic,
                     title: secret.title,
                 }))


### PR DESCRIPTION
maxViews is currently not shown after decrypting the secret. This commit fixes the UI.

The user will always be shown the left over views after the current one.