### PR TITLE
fix: remove base64 encoding

### DIFF
--- a/client/api/upload.js
+++ b/client/api/upload.js
@@ -1,8 +1,5 @@
-import tweetnaclUtil from 'tweetnacl-util';
 import { decrypt } from '../../shared/helpers/crypto';
 import config from '../config';
-
-const { decodeBase64 } = tweetnaclUtil;
 
 export const downloadFile = async (fileData) => {
     const { file, secretId, decryptionKey } = fileData;
@@ -26,7 +23,7 @@ export const downloadFile = async (fileData) => {
         };
     }
 
-    const fileContent = decodeBase64(decrypt(json.content, decryptionKey));
+    const fileContent = new Uint8Array(Buffer.from(decrypt(json.content, decryptionKey), 'hex'));
 
     const a = document.createElement('a');
     const blob = new Blob([fileContent], { type });

--- a/client/api/upload.js
+++ b/client/api/upload.js
@@ -1,3 +1,4 @@
+import { Buffer } from 'buffer/';
 import { decrypt } from '../../shared/helpers/crypto';
 import config from '../config';
 

--- a/client/helpers/zip.js
+++ b/client/helpers/zip.js
@@ -1,6 +1,5 @@
+import { Buffer } from 'buffer/';
 import JSZip from 'jszip';
-import tweetnaclUtil from 'tweetnacl-util';
-const { encodeBase64 } = tweetnaclUtil;
 
 async function getFileContent(file) {
     const reader = new FileReader();
@@ -34,5 +33,5 @@ export async function zipFiles(files) {
 
     const data = await zip.generateAsync({ type: 'uint8array' });
 
-    return encodeBase64(data);
+    return Buffer.from(data).toString('hex');
 }

--- a/client/util/constants.js
+++ b/client/util/constants.js
@@ -1,2 +1,0 @@
-export const USER_LOGIN_CHANGED = 'USER_LOGIN_CHANGED';
-export const USER_LOGIN = 'USER_LOGIN';

--- a/shared/helpers/crypto.js
+++ b/shared/helpers/crypto.js
@@ -1,9 +1,10 @@
+import { Buffer } from 'buffer/';
 import { nanoid } from 'nanoid';
 import tweetnacl from 'tweetnacl';
 import tweetnaclUtil from 'tweetnacl-util';
 
 const { secretbox, randomBytes } = tweetnacl;
-const { decodeUTF8, encodeUTF8, encodeBase64, decodeBase64 } = tweetnaclUtil;
+const { decodeUTF8, encodeUTF8 } = tweetnaclUtil;
 
 export const generateKey = (password = '') => {
     if (password) {
@@ -27,15 +28,13 @@ export const encrypt = (data, userEncryptionKey) => {
     fullMessage.set(nonce);
     fullMessage.set(box, nonce.length);
 
-    const base64FullMessage = encodeBase64(fullMessage);
-
-    return base64FullMessage;
+    return Buffer.from(fullMessage).toString('hex');
 };
 
-export const decrypt = (messageWithNonce, userEncryptionKey) => {
+export const decrypt = (messageWithNonceHex, userEncryptionKey) => {
     const keyUint8Array = decodeUTF8(userEncryptionKey);
 
-    const messageWithNonceAsUint8Array = decodeBase64(messageWithNonce);
+    const messageWithNonceAsUint8Array = Uint8Array.from(Buffer.from(messageWithNonceHex, 'hex'));
     const nonce = messageWithNonceAsUint8Array.slice(0, secretbox.nonceLength);
     const message = messageWithNonceAsUint8Array.slice(
         secretbox.nonceLength,
@@ -48,7 +47,5 @@ export const decrypt = (messageWithNonce, userEncryptionKey) => {
         throw new Error('Could not decrypt message');
     }
 
-    const base64DecryptedMessage = encodeUTF8(decrypted);
-
-    return base64DecryptedMessage;
+    return encodeUTF8(decrypted);
 };

--- a/shared/helpers/crypto.js
+++ b/shared/helpers/crypto.js
@@ -1,4 +1,3 @@
-import { Buffer } from 'buffer/';
 import { nanoid } from 'nanoid';
 import tweetnacl from 'tweetnacl';
 import tweetnaclUtil from 'tweetnacl-util';
@@ -17,7 +16,7 @@ export const generateKey = (password = '') => {
 const newNonce = () => randomBytes(secretbox.nonceLength);
 
 export const encrypt = (data, userEncryptionKey) => {
-    const keyUint8Array = new Uint8Array(Buffer.from(userEncryptionKey));
+    const keyUint8Array = decodeUTF8(userEncryptionKey);
 
     const nonce = newNonce();
     const messageUint8 = decodeUTF8(data);
@@ -34,13 +33,13 @@ export const encrypt = (data, userEncryptionKey) => {
 };
 
 export const decrypt = (messageWithNonce, userEncryptionKey) => {
-    const keyUint8Array = new Uint8Array(Buffer.from(userEncryptionKey));
+    const keyUint8Array = decodeUTF8(userEncryptionKey);
 
     const messageWithNonceAsUint8Array = decodeBase64(messageWithNonce);
     const nonce = messageWithNonceAsUint8Array.slice(0, secretbox.nonceLength);
     const message = messageWithNonceAsUint8Array.slice(
         secretbox.nonceLength,
-        messageWithNonce.length
+        messageWithNonceAsUint8Array.length
     );
 
     const decrypted = secretbox.open(message, nonce, keyUint8Array);


### PR DESCRIPTION
Previously for larger files, the base64 encoding threw an error. This PR will fix that.

However, this will change the entire secret approach, meaning old secrets will no longer work.

Also, I am not sure about this approach. It tries to encrypt everything into memory in the browser, which is not ideal. 200mb files crashed on my MacBook Pro m2.

Streaming is the best solution, but this is a temp solution for most files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced data handling across file processing, zip generation, and encryption/decryption by transitioning from Base64 to hexadecimal encoding. These improvements ensure unified formatting, smoother integration, and increased reliability.

- **Chores**
  - Removed legacy authentication identifiers that were no longer in use to streamline system operations and reduce maintenance complexity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->