### PR TITLE
Update docker-compose.yml to use curl vice wget

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,6 @@ services:
         restart: always
         stop_grace_period: 1m
         healthcheck:
-            test: 'wget -O /dev/null localhost:3000/api/healthz || exit 1'
+            test: 'curl -o /dev/null localhost:3000/api/healthz || exit 1'
             timeout: 5s
             retries: 3


### PR DESCRIPTION
As raised in #421, the health check is failing with wget not included in the base image, using curl fixes this issue  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the health check mechanism for the service in Docker Compose to use curl instead of wget. This may improve compatibility or reliability in some environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->