### PR TITLE
Fix default language not applied

### DIFF
--- a/client/i18n.js
+++ b/client/i18n.js
@@ -19,7 +19,7 @@ i18next
     .use(HttpApi)
     .use(LanguageDetector)
     .init({
-        fallbackLng: language,
+        lng: language,
         detection: {
             order: detectionMethod,
         },


### PR DESCRIPTION
SECRET_FORCED_LANGUAGE is not applied because fallbackLng works only when detection method failed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated language initialization settings to directly specify the initial language, improving clarity of language selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->