### PR TITLE
Fix: toggle Editor between read-only and editable

### DIFF
--- a/client/routes/home/index.jsx
+++ b/client/routes/home/index.jsx
@@ -192,12 +192,21 @@ const Home = () => {
             <FormSection>
                 <div className="space-y-6">
                     <div className="space-y-2">
-                        <Editor
-                            name="text"
-                            content={formData.text}
-                            setContent={(value) => setField('formData.text', value)}
-                            editable={!inputReadOnly}
-                        />
+                        {inputReadOnly ? (
+                            <Editor
+                                key={`ro-${secretId}`}
+                                content={formData.text}
+                                editable={false}
+                            />
+                        ) : (
+                            <Editor
+                                key={`edit-${secretId}`}
+                                name="text"
+                                content={formData.text}
+                                setContent={(value) => setField('formData.text', value)}
+                                editable={true}
+                            />
+                        )}
                         {errors.fields.text && <FieldError message={errors.fields.text} />}
                     </div>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a clear view vs. edit mode for the Home text field. Existing secrets open in a read-only view; new or editable entries open in an editable editor.

* **Bug Fixes**
  * Improved reliability when switching between view and edit modes so content and editability update correctly, preventing accidental edits and stale state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->