### PR TITLE
fix-#414 using border instead of ring to show focus

### DIFF
--- a/client/routes/home/index.jsx
+++ b/client/routes/home/index.jsx
@@ -222,7 +222,7 @@ const Home = () => {
                             onChange={(e) => setField('formData.title', e.target.value)}
                             readOnly={inputReadOnly}
                             className="w-full pl-10 pr-3 py-2.5 bg-gray-900 border border-gray-700 rounded-md
-                                         focus:ring-2 focus:ring-hemmelig focus:border-transparent
+                                        focus:border-hemmelig focus:ring-0 
                                          text-base text-gray-100 placeholder-gray-500"
                         />
                         <p className="mt-2 text-sm text-gray-400">{t('home.title_description')}</p>


### PR DESCRIPTION
fix #414

i choose to use border instead of ring fHere’s a clean and professional way to write your **issue resolution description** 👇

---

### **Description**

When an input field is focused, the borders appear cut off on the left and right sides. This occurs because the `focus:ring` style adds an external outline that increases the element’s overall size, causing layout inconsistencies on mobile devices.

---

### **Root Cause**

The `focus:ring` property in Tailwind adds an outer glow (box-shadow) which extends beyond the element’s box boundaries. On smaller screens or containers with constrained layouts, this glow gets clipped.

---

### **Solution**

Replaced the `focus:ring` effect with a `focus:border` style to maintain consistent element dimensions during focus.
This prevents layout shifts and ensures the focused border remains fully visible.

---

### **Resolution**

* Removed: `focus:ring-*` classes
* Added: `focus:border-hemmelig`
* Result: Input borders now display correctly without being cut off.

### **After**
<img width="437" height="761" alt="image" src="https://github.com/user-attachments/assets/da444067-9a35-4bd2-a9c6-c6eb99ec7490" />

<img width="1001" height="237" alt="image" src="https://github.com/user-attachments/assets/d6ebd095-15d9-494e-a1ec-480e62560c7d" />
