### PR TITLE
Change hemmelig service image to versioned tag

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
     hemmelig:
-        image: hemmelig # https://github.com/HemmeligOrg/Hemmelig.app/tags
+        image: hemmeligapp/hemmelig:vX.X.X # Change it to the version here https://github.com/HemmeligOrg/Hemmelig.app/tags
         hostname: hemmelig
         init: true
         volumes:


### PR DESCRIPTION
Updated the image reference for the hemmelig service to include the version tag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker image reference for the service deployment to use a specific version tag, ensuring consistent and reproducible deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->