### PR TITLE
Add missing '---' separating PVCs in Helm Chart

### DIFF
--- a/helm/hemmelig/templates/pvc.yaml
+++ b/helm/hemmelig/templates/pvc.yaml
@@ -15,6 +15,7 @@ spec:
     requests:
       storage: {{ .Values.persistence.data.size }}
 {{- end }}
+---
 {{- if and .Values.persistence.uploads.enabled (not .Values.persistence.uploads.existingClaim) }}
 apiVersion: v1
 kind: PersistentVolumeClaim


### PR DESCRIPTION
Fixes #483 by adding back the missing yaml file separator to the PVCs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced dedicated persistent storage configuration for uploads with independent settings for storage class, access modes, and capacity. This allows flexible management of upload storage separately from main application storage when enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->