### PR TITLE
Remove security context from Helm Chart

### DIFF
--- a/helm/hemmelig/templates/deployment.yaml
+++ b/helm/hemmelig/templates/deployment.yaml
@@ -28,12 +28,8 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "hemmelig.serviceAccountName" . }}
-      securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
-          securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:

--- a/helm/hemmelig/values.yaml
+++ b/helm/hemmelig/values.yaml
@@ -38,13 +38,7 @@ serviceAccount:
 podAnnotations: {}
 podLabels: {}
 
-podSecurityContext:
-  fsGroup: 1000
 
-securityContext:
-  runAsNonRoot: true
-  runAsUser: 1000
-  runAsGroup: 1000
 
 service:
   type: ClusterIP


### PR DESCRIPTION
Fixes #482 by removing the securityContext

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated Helm deployment configuration by removing security context settings from the chart's values and deployment template.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->