### PR TITLE
feat: make Docker image rootless

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,4 +69,5 @@ ENV DATABASE_URL=file:/app/database/hemmelig.db
 HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
     CMD wget --no-verbose --tries=1 --spider http://localhost:3000/api/health/ready || exit 1
 
+USER app
 ENTRYPOINT ["/app/docker-entrypoint.sh"]

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -1,8 +1,5 @@
 #!/bin/sh
 set -e
 
-# Fix permissions on mounted volumes (runs as root)
-chown -R app:app /app/database /app/uploads 2>/dev/null || true
-
-# Run migrations and start app as app user
-exec gosu app sh -c 'npx prisma migrate deploy && exec npx tsx server.ts'
+# Run migrations and start app
+sh -c 'npx prisma migrate deploy && exec npx tsx server.ts'


### PR DESCRIPTION
I am proposing those two changes to have a truly rootless docker image, as opposed to the current v7 one that starts the entrypoint as root and switches to the `app` user when starting the server.

I changed the Dockerfile to end with `USER app`, so that the entrypoint is started as the `app` user straight away.

The main consequence of this change is that the entrypoint can no longer change ownership of the `/app/database` and `/app/uploads` directories before starting the server: those volumes have to be set with appropriate ownership and permissions prior to starting the container. This is likely a matter of taste but I would rather have a rootless image than the convenience of a root entrypoint that does such things having side effects on the host.

Anyway, this PR is only a proposal. Feel free to turn it down without justification if you feel like it's not worth it. I can always make my own derived image :)

Note: I could not run any image built off of the tip of the `v7` branch but I could successfully test the same changes on the `v7.3.6` tag. Hopefully that would work on the `v7` branch once the other issues are resolved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined container startup process with simplified entrypoint execution.
  * Container now runs with enhanced security configuration using a non-root user account.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->