### PR TITLE
fix: use resolveSettings() in getMaxFileSize() for managed mode compatibility

### DIFF
--- a/api/lib/files.ts
+++ b/api/lib/files.ts
@@ -1,7 +1,7 @@
 import { mkdir } from 'fs/promises';
 import { basename, join, resolve } from 'path';
 import { FILE } from './constants';
-import settingsCache from './settings';
+import { resolveSettings } from './settings';
 
 /** Upload directory path */
 export const UPLOAD_DIR = resolve(process.cwd(), 'uploads');
@@ -30,8 +30,8 @@ export function isPathSafe(filePath: string): boolean {
  * Gets max file size from instance settings (in KB), converted to bytes.
  * Defaults to 10MB if not configured.
  */
-export function getMaxFileSize(): number {
-    const settings = settingsCache.get('instanceSettings');
+export async function getMaxFileSize(): Promise<number> {
+    const settings = await resolveSettings();
     const maxSecretSizeKB = settings?.maxSecretSize ?? FILE.DEFAULT_MAX_SIZE_KB;
     return maxSecretSizeKB * 1024; // Convert KB to bytes
 }

--- a/api/routes/files.ts
+++ b/api/routes/files.ts
@@ -88,7 +88,7 @@ files.post('/', async (c) => {
             return c.json({ error: 'File is required and must be a file.' }, 400);
         }
 
-        const maxFileSize = getMaxFileSize();
+        const maxFileSize = await getMaxFileSize();
         if (file.size > maxFileSize) {
             return c.json(
                 { error: `File size exceeds the limit of ${maxFileSize / 1024 / 1024}MB.` },


### PR DESCRIPTION
## Bug
[Issue #506](https://github.com/HemmeligOrg/Hemmelig.app/issues/506) — File size limit not working correctly in managed mode

## Fix
The `getMaxFileSize()` function was using `settingsCache.get('instanceSettings')` which only works for database-stored settings. In managed mode (`HEMMELIG_MANAGED=true`), settings come from environment variables and are accessed via `resolveSettings()`.

This change:
- Updates `getMaxFileSize()` to use `resolveSettings()` instead of direct cache access
- Makes the function async to support the database fallback in `resolveSettings()`
- Updates the call site in the upload route to await the result

## Testing
The fix ensures that when `HEMMELIG_MAX_SECRET_SIZE=512000` is set in managed mode, file uploads will correctly respect the 500MB limit instead of falling back to the 10MB default.

Greetings, saschabuehrle

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced file upload size validation to support dynamic configuration retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->