### PR TITLE
fix(api): allow bearer API keys for POST /api/secrets

### DIFF
--- a/api/middlewares/auth.ts
+++ b/api/middlewares/auth.ts
@@ -1,4 +1,5 @@
 import { createHash } from 'crypto';
+import type { Context } from 'hono';
 import { createMiddleware } from 'hono/factory';
 import { auth } from '../auth';
 import prisma from '../lib/db';
@@ -9,6 +10,61 @@ type Env = {
         session: typeof auth.$Infer.Session.session | null;
     };
 };
+
+type ApiKeyAuthResult = { user: typeof auth.$Infer.Session.user } | { error: string; status: 401 };
+type AuthContext = Context<Env>;
+
+async function authenticateApiKeyHeader(authHeader: string | undefined): Promise<ApiKeyAuthResult> {
+    if (!authHeader?.startsWith('Bearer ')) {
+        return { error: 'Unauthorized', status: 401 };
+    }
+
+    const apiKey = authHeader.substring(7);
+    if (!apiKey.startsWith('hemmelig_')) {
+        return { error: 'Invalid API key format', status: 401 };
+    }
+
+    try {
+        const keyHash = createHash('sha256').update(apiKey).digest('hex');
+
+        const apiKeyRecord = await prisma.apiKey.findUnique({
+            where: { keyHash },
+            include: { user: true },
+        });
+
+        if (!apiKeyRecord) {
+            return { error: 'Invalid API key', status: 401 };
+        }
+
+        if (apiKeyRecord.expiresAt && new Date() > apiKeyRecord.expiresAt) {
+            return { error: 'API key has expired', status: 401 };
+        }
+
+        prisma.apiKey
+            .update({
+                where: { id: apiKeyRecord.id },
+                data: { lastUsedAt: new Date() },
+            })
+            .catch(() => {});
+
+        return { user: apiKeyRecord.user as typeof auth.$Infer.Session.user };
+    } catch (error) {
+        console.error('API key auth error:', error);
+        return { error: 'Authentication failed', status: 401 };
+    }
+}
+
+async function setApiKeyUserFromHeader(c: AuthContext, authHeader: string | undefined) {
+    const result = await authenticateApiKeyHeader(authHeader);
+    if ('error' in result) {
+        return c.json({ error: result.error }, result.status);
+    }
+
+    c.set('user', result.user);
+    c.set('session', null);
+
+    return null;
+}
 
 export const authMiddleware = createMiddleware<Env>(async (c, next) => {
     const user = c.get('user');
@@ -43,49 +99,30 @@ export const apiKeyOrAuthMiddleware = createMiddleware<Env>(async (c, next) => {
         return next();
     }
 
-    // Check for API key in Authorization header
-    const authHeader = c.req.header('Authorization');
-    if (!authHeader?.startsWith('Bearer ')) {
-        return c.json({ error: 'Unauthorized' }, 401);
+    const authResponse = await setApiKeyUserFromHeader(c, c.req.header('Authorization'));
+    if (authResponse) {
+        return authResponse;
     }
 
-    const apiKey = authHeader.substring(7);
-    if (!apiKey.startsWith('hemmelig_')) {
-        return c.json({ error: 'Invalid API key format' }, 401);
-    }
+    return next();
+});
 
-    try {
-        const keyHash = createHash('sha256').update(apiKey).digest('hex');
-
-        const apiKeyRecord = await prisma.apiKey.findUnique({
-            where: { keyHash },
-            include: { user: true },
-        });
-
-        if (!apiKeyRecord) {
-            return c.json({ error: 'Invalid API key' }, 401);
-        }
-
-        // Check if key is expired
-        if (apiKeyRecord.expiresAt && new Date() > apiKeyRecord.expiresAt) {
-            return c.json({ error: 'API key has expired' }, 401);
-        }
-
-        // Update last used timestamp (fire and forget)
-        prisma.apiKey
-            .update({
-                where: { id: apiKeyRecord.id },
-                data: { lastUsedAt: new Date() },
-            })
-            .catch(() => {});
-
-        // Set user from API key
-        c.set('user', apiKeyRecord.user as typeof auth.$Infer.Session.user);
-        c.set('session', null);
-
+// Middleware that accepts session auth OR API key auth, but also allows anonymous access
+export const optionalApiKeyOrAuthMiddleware = createMiddleware<Env>(async (c, next) => {
+    const sessionUser = c.get('user');
+    if (sessionUser) {
         return next();
-    } catch (error) {
-        console.error('API key auth error:', error);
-        return c.json({ error: 'Authentication failed' }, 401);
     }
+
+    const authHeader = c.req.header('Authorization');
+    if (!authHeader) {
+        return next();
+    }
+
+    const authResponse = await setApiKeyUserFromHeader(c, authHeader);
+    if (authResponse) {
+        return authResponse;
+    }
+
+    return next();
 });

--- a/api/openapi.ts
+++ b/api/openapi.ts
@@ -138,7 +138,7 @@ const spec = {
                 tags: ['Secrets'],
                 summary: 'List user secrets',
                 description: 'Get paginated list of secrets created by the authenticated user',
-                security: [{ cookieAuth: [] }],
+                security: [{ cookieAuth: [] }, { bearerAuth: [] }],
                 parameters: [
                     {
                         name: 'page',
@@ -176,7 +176,8 @@ const spec = {
                 tags: ['Secrets'],
                 summary: 'Create a new secret',
                 description:
-                    'Create a new encrypted secret. The secret content should be encrypted client-side before sending.',
+                    'Create a new encrypted secret. Authentication is optional: anonymous creation works when the instance does not require registered users, and authenticated creation supports either a session cookie or Authorization: Bearer hemmelig_... . The secret and title fields must be sent as JSON-serialized Uint8Array objects.',
+                security: [{}, { cookieAuth: [] }, { bearerAuth: [] }],
                 requestBody: {
                     required: true,
                     content: {
@@ -1369,8 +1370,28 @@ const spec = {
                 type: 'object',
                 required: ['secret', 'salt', 'expiresAt'],
                 properties: {
-                    secret: { type: 'string', description: 'Encrypted secret content' },
-                    title: { type: 'string', nullable: true },
+                    secret: {
+                        type: 'object',
+                        additionalProperties: {
+                            type: 'integer',
+                            minimum: 0,
+                            maximum: 255,
+                        },
+                        description:
+                            'Encrypted secret content sent as a JSON-serialized Uint8Array',
+                        example: { '0': 116, '1': 101, '2': 115, '3': 116 },
+                    },
+                    title: {
+                        type: 'object',
+                        nullable: true,
+                        additionalProperties: {
+                            type: 'integer',
+                            minimum: 0,
+                            maximum: 255,
+                        },
+                        description: 'Encrypted title as a JSON-serialized Uint8Array',
+                        example: { '0': 78, '1': 111, '2': 116, '3': 101 },
+                    },
                     salt: { type: 'string', description: 'Salt used for encryption' },
                     password: { type: 'string', description: 'Optional password protection' },
                     expiresAt: {

--- a/api/routes/secrets.ts
+++ b/api/routes/secrets.ts
@@ -7,7 +7,7 @@ import { buildPaginationMeta } from '../lib/route-utils';
 import { resolveSettings } from '../lib/settings';
 import { handleNotFound } from '../lib/utils';
 import { sendWebhook } from '../lib/webhook';
-import { apiKeyOrAuthMiddleware } from '../middlewares/auth';
+import { apiKeyOrAuthMiddleware, optionalApiKeyOrAuthMiddleware } from '../middlewares/auth';
 import { ipRestriction } from '../middlewares/ip-restriction';
 import {
     createSecretsSchema,
@@ -231,68 +231,78 @@ const app = new Hono<{
             );
         }
     })
-    .post('/', zValidator('json', createSecretsSchema), async (c) => {
-        try {
-            const user = c.get('user');
+    .post(
+        '/',
+        optionalApiKeyOrAuthMiddleware,
+        zValidator('json', createSecretsSchema),
+        async (c) => {
+            try {
+                const user = c.get('user');
 
-            // Check if only registered users can create secrets
-            const settings = await resolveSettings();
-            if (settings?.requireRegisteredUser && !user) {
-                return c.json({ error: 'Only registered users can create secrets' }, 401);
-            }
+                // Check if only registered users can create secrets
+                const settings = await resolveSettings();
+                if (settings?.requireRegisteredUser && !user) {
+                    return c.json({ error: 'Only registered users can create secrets' }, 401);
+                }
 
-            const validatedData = c.req.valid('json');
+                const validatedData = c.req.valid('json');
 
-            // Enforce dynamic maxSecretSize from instance settings (in KB)
-            const maxSizeKB = settings?.maxSecretSize ?? 1024;
-            const maxSizeBytes = maxSizeKB * 1024;
-            if (validatedData.secret.length > maxSizeBytes) {
-                return c.json({ error: `Secret exceeds maximum size of ${maxSizeKB} KB` }, 413);
-            }
+                // Enforce dynamic maxSecretSize from instance settings (in KB)
+                const maxSizeKB = settings?.maxSecretSize ?? 1024;
+                const maxSizeBytes = maxSizeKB * 1024;
+                if (validatedData.secret.length > maxSizeBytes) {
+                    return c.json({ error: `Secret exceeds maximum size of ${maxSizeKB} KB` }, 413);
+                }
 
-            const { expiresAt, password, fileIds, salt, title, ...rest } = validatedData;
+                const { expiresAt, password, fileIds, salt, title, ...rest } = validatedData;
 
-            const data: SecretCreateData = {
-                ...rest,
-                salt,
-                // Title is required by the database, default to empty Uint8Array if not provided
-                title: title ?? new Uint8Array(0),
-                password: password ? await hash(password) : null,
-                expiresAt: new Date(Date.now() + expiresAt * 1000),
-                ...(fileIds && {
-                    files: { connect: fileIds.map((id: string) => ({ id })) },
-                }),
-            };
+                const data: SecretCreateData = {
+                    ...rest,
+                    salt,
+                    // Title is required by the database, default to empty Uint8Array if not provided
+                    title: title ?? new Uint8Array(0),
+                    password: password ? await hash(password) : null,
+                    expiresAt: new Date(Date.now() + expiresAt * 1000),
+                    ...(fileIds && {
+                        files: { connect: fileIds.map((id: string) => ({ id })) },
+                    }),
+                };
 
-            if (user) {
-                data.userId = user.id;
-            }
+                if (user) {
+                    data.userId = user.id;
+                }
 
-            const item = await prisma.secrets.create({ data });
+                const item = await prisma.secrets.create({ data });
 
-            return c.json({ id: item.id }, 201);
-        } catch (error: unknown) {
-            console.error('Failed to create secrets:', error);
+                return c.json({ id: item.id }, 201);
+            } catch (error: unknown) {
+                console.error('Failed to create secrets:', error);
 
-            if (error && typeof error === 'object' && 'code' in error && error.code === 'P2002') {
-                const prismaError = error as { meta?: { target?: string } };
+                if (
+                    error &&
+                    typeof error === 'object' &&
+                    'code' in error &&
+                    error.code === 'P2002'
+                ) {
+                    const prismaError = error as { meta?: { target?: string } };
+                    return c.json(
+                        {
+                            error: 'Could not create secrets',
+                            details: prismaError.meta?.target,
+                        },
+                        409
+                    );
+                }
+
                 return c.json(
                     {
-                        error: 'Could not create secrets',
-                        details: prismaError.meta?.target,
+                        error: 'Failed to create secret',
                     },
-                    409
+                    500
                 );
             }
-
-            return c.json(
-                {
-                    error: 'Failed to create secret',
-                },
-                500
-            );
         }
-    })
+    )
     .delete('/:id', zValidator('param', secretsIdParamSchema), async (c) => {
         try {
             const { id } = c.req.valid('param');

--- a/api/tests/secrets-create-auth.hurl
+++ b/api/tests/secrets-create-auth.hurl
@@ -1,0 +1,157 @@
+# Assumes a fresh local instance is running on localhost:5173.
+# `localhost` keeps the browser-style session cookie flow, while `127.0.0.1`
+# avoids reusing that cookie for the anonymous and bearer-only cases.
+
+# Bootstrap the instance with an admin user.
+POST http://localhost:5173/api/setup/complete
+Content-Type: application/json
+Origin: http://localhost:5173
+{
+  "email": "hurl-admin@hemmelig.local",
+  "password": "HurlAdminPass123!",
+  "username": "hurladmin",
+  "name": "Hurl Admin"
+}
+HTTP 200
+[Asserts]
+jsonpath "$.success" == true
+
+# Sign in to obtain a session cookie for admin-only settings and API key creation.
+POST http://localhost:5173/api/auth/sign-in/email
+Content-Type: application/json
+Origin: http://localhost:5173
+{
+  "email": "hurl-admin@hemmelig.local",
+  "password": "HurlAdminPass123!"
+}
+HTTP 200
+[Asserts]
+header "set-cookie" contains "better-auth.session_token="
+
+# Mint an API key that will be used for authenticated secret creation.
+POST http://localhost:5173/api/api-keys
+Content-Type: application/json
+Origin: http://localhost:5173
+{
+  "name": "hurl-create-secret",
+  "expiresInDays": 30
+}
+HTTP 201
+[Captures]
+api_key: jsonpath "$.key"
+[Asserts]
+jsonpath "$.key" matches "^hemmelig_"
+
+# Require authenticated users for secret creation.
+PUT http://localhost:5173/api/instance/settings
+Content-Type: application/json
+Origin: http://localhost:5173
+{
+  "requireRegisteredUser": true
+}
+HTTP 200
+[Asserts]
+jsonpath "$.requireRegisteredUser" == true
+
+# A valid bearer API key should satisfy the registered-user requirement.
+POST http://127.0.0.1:5173/api/secrets
+Content-Type: application/json
+Authorization: Bearer {{api_key}}
+{
+  "secret": { "0": 116, "1": 101, "2": 115, "3": 116 },
+  "title": { "0": 78, "1": 111, "2": 116, "3": 101 },
+  "salt": "hurl-api-key-salt",
+  "expiresAt": 3600,
+  "views": 1,
+  "isBurnable": true,
+  "ipRange": null
+}
+HTTP 201
+[Captures]
+api_key_secret_id: jsonpath "$.id"
+[Asserts]
+jsonpath "$.id" exists
+
+# No auth must still fail while registered users are required.
+POST http://127.0.0.1:5173/api/secrets
+Content-Type: application/json
+{
+  "secret": { "0": 110, "1": 111, "2": 45, "3": 97, "4": 117, "5": 116, "6": 104 },
+  "title": { "0": 78, "1": 111, "2": 32, "3": 65, "4": 117, "5": 116, "6": 104 },
+  "salt": "hurl-no-auth-salt",
+  "expiresAt": 3600,
+  "views": 1,
+  "isBurnable": true,
+  "ipRange": null
+}
+HTTP 401
+[Asserts]
+jsonpath "$.error" == "Only registered users can create secrets"
+
+# Malformed or invalid bearer auth must fail clearly.
+POST http://127.0.0.1:5173/api/secrets
+Content-Type: application/json
+Authorization: Bearer invalid_key
+{
+  "secret": { "0": 98, "1": 97, "2": 100 },
+  "title": { "0": 66, "1": 97, "2": 100 },
+  "salt": "hurl-invalid-bearer-salt",
+  "expiresAt": 3600,
+  "views": 1,
+  "isBurnable": true,
+  "ipRange": null
+}
+HTTP 401
+[Asserts]
+jsonpath "$.error" == "Invalid API key format"
+
+# Well-formed but nonexistent bearer keys must also fail clearly.
+POST http://127.0.0.1:5173/api/secrets
+Content-Type: application/json
+Authorization: Bearer hemmelig_notarealkey
+{
+  "secret": { "0": 98, "1": 97, "2": 100, "3": 50 },
+  "title": { "0": 66, "1": 97, "2": 100, "3": 50 },
+  "salt": "hurl-invalid-real-format-salt",
+  "expiresAt": 3600,
+  "views": 1,
+  "isBurnable": true,
+  "ipRange": null
+}
+HTTP 401
+[Asserts]
+jsonpath "$.error" == "Invalid API key"
+
+# Relax the instance policy and verify anonymous creation still works.
+PUT http://localhost:5173/api/instance/settings
+Content-Type: application/json
+Origin: http://localhost:5173
+{
+  "requireRegisteredUser": false
+}
+HTTP 200
+[Asserts]
+jsonpath "$.requireRegisteredUser" == false
+
+POST http://127.0.0.1:5173/api/secrets
+Content-Type: application/json
+{
+  "secret": { "0": 111, "1": 112, "2": 101, "3": 110 },
+  "title": { "0": 79, "1": 112, "2": 101, "3": 110 },
+  "salt": "hurl-anon-salt",
+  "expiresAt": 3600,
+  "views": 1,
+  "isBurnable": true,
+  "ipRange": null
+}
+HTTP 201
+[Asserts]
+jsonpath "$.id" exists
+
+# Existing authenticated GET behavior should remain intact for API keys.
+GET http://127.0.0.1:5173/api/secrets
+Authorization: Bearer {{api_key}}
+HTTP 200
+[Asserts]
+jsonpath "$.data[0].id" exists
+jsonpath "$.meta.total" >= 1

--- a/docs/api.md
+++ b/docs/api.md
@@ -83,8 +83,10 @@ For endpoints requiring admin access, the authenticated user must have the `admi
 ```bash
 curl -X POST https://your-instance.com/api/secrets \
   -H "Content-Type: application/json" \
+  -H "Authorization: Bearer hemmelig_your_api_key_here" \
   -d '{
-    "secret": "BASE64_ENCRYPTED_CONTENT",
+    "secret": { "0": 116, "1": 101, "2": 115, "3": 116 },
+    "title": { "0": 78, "1": 111, "2": 116, "3": 101 },
     "salt": "ENCRYPTION_SALT",
     "expiresAt": 3600,
     "views": 1
@@ -102,5 +104,6 @@ Response:
 ## Important Notes
 
 - **Client-side encryption:** All secret content should be encrypted client-side before sending to the API. The server only stores encrypted data.
+- **Serialized `Uint8Array` fields:** `secret` and `title` must be sent as JSON-serialized `Uint8Array` objects such as `{ "0": 116, "1": 101, "2": 115, "3": 116 }`.
 - **Decryption keys:** Never send decryption keys to the server. They should be passed via URL fragments (`#key=...`) which are not transmitted to the server.
 - **Rate limiting:** API requests may be rate-limited based on instance settings.


### PR DESCRIPTION
## Summary

This fixes an inconsistency in the secrets API where bearer API keys worked for listing secrets, but not for creating them when `requireRegisteredUser=true`.

Before this change, `POST /api/secrets` only relied on the existing session user in the request context. That meant browser-based requests could succeed thanks to a session cookie, while bearer-only clients received `Only registered users can create secrets` even with a valid API key.

## What changed

- extracted API key header authentication into shared helpers in `api/middlewares/auth.ts`
- added `optionalApiKeyOrAuthMiddleware`
- applied optional auth to `POST /api/secrets`
- updated OpenAPI and docs to reflect the actual supported auth modes
- documented the expected JSON-serialized `Uint8Array` payload format for `secret` and `title`
- added Hurl coverage for:
  - valid bearer auth
  - no auth with `requireRegisteredUser=true`
  - malformed bearer auth
  - well-formed but invalid bearer auth
  - anonymous creation when `requireRegisteredUser=false`
  - existing `GET /api/secrets` bearer behavior

## Why this approach

Using the existing strict middleware directly on `POST /api/secrets` would have broken anonymous creation entirely. The new optional middleware preserves current behavior:

- if anonymous creation is allowed, requests without auth still work
- if `requireRegisteredUser=true`, a valid session or bearer API key satisfies the requirement
- invalid bearer headers still fail with `401`

## Result

`POST /api/secrets` now behaves consistently with the rest of the API and works properly for bearer-based automation clients, while keeping anonymous creation intact when enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added API key authentication via Bearer tokens for programmatic API access.
  * Introduced optional authentication for secret creation and listing endpoints.

* **Bug Fixes**
  * Improved error handling for authentication failures and duplicate secret creation conflicts.

* **Tests**
  * Added comprehensive test coverage for API key authentication scenarios.

* **Documentation**
  * Updated API specifications and examples to reflect Bearer token authentication support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->