### PR TITLE
fix burnable secrets overrided by max_views parameter

### DIFF
--- a/api/routes/secrets.ts
+++ b/api/routes/secrets.ts
@@ -141,8 +141,8 @@ const app = new Hono<{
                         }
                     }
 
-                    // Consume the view atomically with retrieval
-                    const newViews = item.views! - 1;
+                    // Consume the view atomically with retrieval if the secret is not burnable
+                    const newViews = item.isBurnable ? item.views : item.views! - 1;
 
                     // Decrement views (don't delete yet — files may still need downloading)
                     // The cleanup job handles deletion of secrets with views=0
@@ -204,6 +204,7 @@ const app = new Hono<{
                     views: true,
                     title: true,
                     password: true,
+                    isBurnable: true,
                 },
             });
 


### PR DESCRIPTION
Trying to fix issue #468 by checking if a secret is burnable instead of just checking remaining views number
maybe we need to "fix or rewrite" the conditional below to send the webhook event "burnt" 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed secret view counter behavior for burnable secrets
  * Enhanced secret status check endpoint to include burn state information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->