### PR TITLE
Clear add-user form after closing

### DIFF
--- a/src/components/AddUserModal.tsx
+++ b/src/components/AddUserModal.tsx
@@ -1,5 +1,5 @@
 import { Key, Mail, Shield, User } from 'lucide-react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Modal } from './Modal';
 import { ModalInput } from './ModalInput';
@@ -25,6 +25,16 @@ export function AddUserModal({ isOpen, onClose, onSave }: AddUserModalProps) {
     const [email, setEmail] = useState('');
     const [password, setPassword] = useState('');
     const [role, setRole] = useState('user');
+
+    useEffect(() => {
+        if (!isOpen) {
+            setName('');
+            setUsername('');
+            setEmail('');
+            setPassword('');
+            setRole('user');
+        }
+    }, [isOpen]);
 
     const handleSave = () => {
         onSave({

--- a/src/components/AddUserModal.tsx
+++ b/src/components/AddUserModal.tsx
@@ -1,5 +1,5 @@
 import { Key, Mail, Shield, User } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Modal } from './Modal';
 import { ModalInput } from './ModalInput';
@@ -25,8 +25,10 @@ export function AddUserModal({ isOpen, onClose, onSave }: AddUserModalProps) {
     const [email, setEmail] = useState('');
     const [password, setPassword] = useState('');
     const [role, setRole] = useState('user');
+    const [previousIsOpen, setPreviousIsOpen] = useState(isOpen);
 
-    useEffect(() => {
+    if (isOpen !== previousIsOpen) {
+        setPreviousIsOpen(isOpen);
         if (!isOpen) {
             setName('');
             setUsername('');
@@ -34,7 +36,7 @@ export function AddUserModal({ isOpen, onClose, onSave }: AddUserModalProps) {
             setPassword('');
             setRole('user');
         }
-    }, [isOpen]);
+    }
 
     const handleSave = () => {
         onSave({

--- a/src/components/ModalInput.tsx
+++ b/src/components/ModalInput.tsx
@@ -45,6 +45,7 @@ export function ModalInput({
                 <Icon className={iconClass} />
                 {as === 'select' ? (
                     <select
+                        aria-label={label}
                         value={value}
                         onChange={(e) => onChange(e.target.value)}
                         className={`${inputClass} appearance-none`}
@@ -57,6 +58,7 @@ export function ModalInput({
                     </select>
                 ) : (
                     <input
+                        aria-label={label}
                         type={type ?? 'text'}
                         value={value}
                         onChange={(e) => onChange(e.target.value)}

--- a/tests/e2e/users.spec.ts
+++ b/tests/e2e/users.spec.ts
@@ -5,22 +5,26 @@ test.describe('User management', () => {
         await page.goto('/dashboard/users');
         await page.getByRole('button', { name: 'Add User' }).click();
 
-        const modal = page.getByRole('heading', { name: 'Add User' }).locator('../..');
-        const inputs = modal.locator('input');
-        await inputs.nth(0).fill('Second User');
-        await inputs.nth(1).fill('seconduser');
-        await inputs.nth(2).fill('second@example.com');
-        await inputs.nth(3).fill('SecondPassword123!');
-        await modal.locator('select').selectOption('admin');
-        await modal.getByRole('button', { name: 'Add User' }).click();
+        const nameInput = page.getByLabel('Name', { exact: true });
+        const usernameInput = page.getByLabel('Username', { exact: true });
+        const emailInput = page.getByLabel('Email', { exact: true });
+        const passwordInput = page.getByLabel('Password', { exact: true });
+        const roleSelect = page.getByLabel('Role', { exact: true });
 
-        await expect(modal).toBeHidden();
+        await nameInput.fill('Second User');
+        await usernameInput.fill('seconduser');
+        await emailInput.fill('second@example.com');
+        await passwordInput.fill('SecondPassword123!');
+        await roleSelect.selectOption('admin');
+        await page.getByRole('button', { name: 'Add User' }).last().click();
+
+        await expect(page.getByRole('heading', { name: 'Add User' })).toBeHidden();
         await page.getByRole('button', { name: 'Add User' }).click();
 
-        await expect(inputs.nth(0)).toHaveValue('');
-        await expect(inputs.nth(1)).toHaveValue('');
-        await expect(inputs.nth(2)).toHaveValue('');
-        await expect(inputs.nth(3)).toHaveValue('');
-        await expect(modal.locator('select')).toHaveValue('user');
+        await expect(nameInput).toHaveValue('');
+        await expect(usernameInput).toHaveValue('');
+        await expect(emailInput).toHaveValue('');
+        await expect(passwordInput).toHaveValue('');
+        await expect(roleSelect).toHaveValue('user');
     });
 });

--- a/tests/e2e/users.spec.ts
+++ b/tests/e2e/users.spec.ts
@@ -1,0 +1,26 @@
+import { expect, test } from './fixtures';
+
+test.describe('User management', () => {
+    test('clears the add user form after creating a user', async ({ authenticatedPage: page }) => {
+        await page.goto('/dashboard/users');
+        await page.getByRole('button', { name: 'Add User' }).click();
+
+        const modal = page.getByRole('heading', { name: 'Add User' }).locator('../..');
+        const inputs = modal.locator('input');
+        await inputs.nth(0).fill('Second User');
+        await inputs.nth(1).fill('seconduser');
+        await inputs.nth(2).fill('second@example.com');
+        await inputs.nth(3).fill('SecondPassword123!');
+        await modal.locator('select').selectOption('admin');
+        await modal.getByRole('button', { name: 'Add User' }).click();
+
+        await expect(modal).toBeHidden();
+        await page.getByRole('button', { name: 'Add User' }).click();
+
+        await expect(inputs.nth(0)).toHaveValue('');
+        await expect(inputs.nth(1)).toHaveValue('');
+        await expect(inputs.nth(2)).toHaveValue('');
+        await expect(inputs.nth(3)).toHaveValue('');
+        await expect(modal.locator('select')).toHaveValue('user');
+    });
+});


### PR DESCRIPTION
## Summary

- clear every add-user field when the modal closes
- restore the default `user` role
- add Playwright coverage for reopening the form after creating a user

## Why

`AddUserModal` kept its local state after closing, so reopening it exposed the previous user's name, email, username, password, and role. Resetting on the closed state removes that sensitive stale data while preserving values when a submission fails and the modal remains open.

Closes #504.

## Validation

- Prettier check passed for the changed files
- Vite production build passed under Node 25.9.0
- `git diff --check` passed
- targeted Playwright regression test added

The targeted Playwright run could not complete locally: the repository's `webServer` command uses POSIX environment-variable syntax on Windows; after starting the server separately, Prisma's global test setup exited with a schema-engine error before executing tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The “Add User” modal now reliably resets all form fields when reopened after saving, including restoring the default role.
* **Accessibility**
  * Improved accessibility labeling for modal input controls to better support assistive technologies.
* **Tests**
  * Added end-to-end coverage to confirm the user creation flow and modal reset behavior for subsequent entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->