### PR TITLE
fix: avoid analytics error banner when tracking is disabled

### DIFF
--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,4 +1,4 @@
-import { api } from './api';
+import { apiRaw } from './api';
 
 const TRACKED_PATHS = ['/', '/secret'];
 
@@ -19,7 +19,7 @@ export async function trackPageView(path: string): Promise<void> {
     const normalizedPath = path.startsWith('/secret/') ? '/secret' : path;
 
     try {
-        await api.analytics.track.$post({ json: { path: normalizedPath } });
+        await apiRaw.analytics.track.$post({ json: { path: normalizedPath } });
     } catch {
         // Silently fail - analytics should not affect user experience
     }


### PR DESCRIPTION
## Summary

- use the existing raw Hono client for best-effort page-view tracking
- keep expected non-2xx analytics responses out of the global error store

## Why

When `HEMMELIG_ANALYTICS_ENABLED=false`, `POST /api/analytics/track` returns 403. The normal API client turns that expected response into a user-visible global error, which contradicts the tracker's silent-failure behavior.

Using `apiRaw` preserves the server-side disable check while preventing the red error banner.

## Testing

The change is type-preserving because `api` and `apiRaw` use the same generated `AppType` client. Repository CI should validate formatting and build behavior.

Fixes #477


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved page-view analytics event delivery by using the appropriate request handling for tracking events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->