### PR TITLE
fix: remove duplicate TipTap Link extension

### DIFF
--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -930,6 +930,7 @@ const extensions = [
         validate: (href) => /^https?:\/\//.test(href),
     }),
     StarterKit.configure({
+        link: false,
         bulletList: {
             keepMarks: true,
             keepAttributes: false,


### PR DESCRIPTION
## Summary

- disable StarterKit's bundled `Link` extension
- keep the existing project-specific `Link.configure(...)` behavior unchanged

## Why

TipTap v3 includes `Link` in `StarterKit`. Registering the explicit project extension alongside the bundled copy produces:

`[tiptap warn]: Duplicate extension names found: ['link']`

Disabling only StarterKit's copy preserves the existing autolink, protocol, and URL-validation settings.

## Testing

The diff is limited to the documented TipTap configuration switch. Repository CI should validate formatting and compilation.

Addresses the duplicate-extension portion of #478.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled the editor’s built-in link behavior to prevent unintended link handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->