### PR TITLE
[codex] make request timeout configurable

### DIFF
--- a/api/app.ts
+++ b/api/app.ts
@@ -99,7 +99,10 @@ app.use(async (c, next) => {
 app.use(logger());
 app.use(trimTrailingSlash());
 app.use(`/*`, requestId());
-app.use(`/*`, timeout(15 * 1000)); // 15 seconds timeout to the API calls
+const requestTimeout = config.get<number>('server.requestTimeout', 15);
+if (requestTimeout > 0) {
+    app.use(`/*`, timeout(requestTimeout * 1000));
+}
 app.use(ratelimit);
 
 // https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/ETag

--- a/api/config.ts
+++ b/api/config.ts
@@ -204,6 +204,7 @@ const managedSettings = isManaged
 const config = {
     server: {
         port: Number(process.env.HEMMELIG_PORT) || 3000,
+        requestTimeout: parseInteger(process.env.HEMMELIG_REQUEST_TIMEOUT) ?? 15,
     },
     trustedOrigins: [
         ...(!isProduction ? ['http://localhost:5173'] : []),

--- a/docs/env.md
+++ b/docs/env.md
@@ -12,12 +12,13 @@ Complete reference for all environment variables supported by Hemmelig.
 
 ## Server Configuration
 
-| Variable                  | Description                                      | Default       |
-| ------------------------- | ------------------------------------------------ | ------------- |
-| `NODE_ENV`                | Environment mode (`production` or `development`) | `development` |
-| `HEMMELIG_PORT`           | Port the server listens on                       | `3000`        |
-| `HEMMELIG_BASE_URL`       | Public URL of your instance (required for OAuth) | -             |
-| `HEMMELIG_TRUSTED_ORIGIN` | Additional trusted origin for CORS               | -             |
+| Variable                   | Description                                                   | Default       |
+| -------------------------- | ------------------------------------------------------------- | ------------- |
+| `NODE_ENV`                 | Environment mode (`production` or `development`)              | `development` |
+| `HEMMELIG_PORT`            | Port the server listens on                                    | `3000`        |
+| `HEMMELIG_REQUEST_TIMEOUT` | API request timeout in seconds (`0` disables the app timeout) | `15`          |
+| `HEMMELIG_BASE_URL`        | Public URL of your instance (required for OAuth)              | -             |
+| `HEMMELIG_TRUSTED_ORIGIN`  | Additional trusted origin for CORS                            | -             |
 
 ## General Settings
 
@@ -136,6 +137,7 @@ BETTER_AUTH_URL=https://secrets.example.com
 # Server
 NODE_ENV=production
 HEMMELIG_PORT=3000
+HEMMELIG_REQUEST_TIMEOUT=60
 HEMMELIG_TRUSTED_ORIGIN=https://secrets.example.com
 
 # Instance

--- a/docs/env.md
+++ b/docs/env.md
@@ -12,13 +12,13 @@ Complete reference for all environment variables supported by Hemmelig.
 
 ## Server Configuration
 
-| Variable                   | Description                                                   | Default       |
-| -------------------------- | ------------------------------------------------------------- | ------------- |
-| `NODE_ENV`                 | Environment mode (`production` or `development`)              | `development` |
-| `HEMMELIG_PORT`            | Port the server listens on                                    | `3000`        |
-| `HEMMELIG_REQUEST_TIMEOUT` | API request timeout in seconds (`0` disables the app timeout) | `15`          |
-| `HEMMELIG_BASE_URL`        | Public URL of your instance (required for OAuth)              | -             |
-| `HEMMELIG_TRUSTED_ORIGIN`  | Additional trusted origin for CORS                            | -             |
+| Variable                   | Description                                                                | Default       |
+| -------------------------- | -------------------------------------------------------------------------- | ------------- |
+| `NODE_ENV`                 | Environment mode (`production` or `development`)                           | `development` |
+| `HEMMELIG_PORT`            | Port the server listens on                                                 | `3000`        |
+| `HEMMELIG_REQUEST_TIMEOUT` | API request timeout in seconds (zero or negative disables the app timeout) | `15`          |
+| `HEMMELIG_BASE_URL`        | Public URL of your instance (required for OAuth)                           | -             |
+| `HEMMELIG_TRUSTED_ORIGIN`  | Additional trusted origin for CORS                                         | -             |
 
 ## General Settings
 


### PR DESCRIPTION
## Summary
- read `HEMMELIG_REQUEST_TIMEOUT` in seconds, keeping the current 15-second default
- apply Hono's timeout middleware only when the configured value is greater than zero, so `0` disables the app-level timeout
- document the new setting and a production example

Fixes #551

## Validation
- unset: defaults to 15 seconds
- `HEMMELIG_REQUEST_TIMEOUT=0`: app timeout disabled
- `HEMMELIG_REQUEST_TIMEOUT=60`: custom timeout applied
- `npm run build`: passed (8,246 modules transformed)
- `git diff --check`: passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Server request timeouts can now be configured through `HEMMELIG_REQUEST_TIMEOUT`.
  - Timeout values are specified in seconds and default to 15 seconds.
  - Set the value to zero or a negative number to disable request timeout handling.

- **Documentation**
  - Added configuration guidance, including timeout behavior and a production setup example.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->