### PR TITLE
Feature: Maximum password tries before burning the secret and files

### DIFF
--- a/api/jobs/expired.ts
+++ b/api/jobs/expired.ts
@@ -1,5 +1,5 @@
-import { unlink } from 'fs/promises';
 import prisma from '../lib/db';
+import { unlinkFiles } from '../lib/files';
 
 export const deleteExpiredSecrets = async () => {
     try {
@@ -39,19 +39,7 @@ export const deleteOrphanedFiles = async () => {
         }
 
         // Delete files from disk in parallel for better performance
-        const deleteResults = await Promise.allSettled(
-            orphanedFiles.map((file) => unlink(file.path))
-        );
-
-        // Log any failures (file may already be deleted or inaccessible)
-        deleteResults.forEach((result, index) => {
-            if (result.status === 'rejected') {
-                console.error(
-                    `Failed to delete file from disk: ${orphanedFiles[index].path}`,
-                    result.reason
-                );
-            }
-        });
+        await unlinkFiles(orphanedFiles.map((file) => file.path));
 
         // Delete orphaned file records from database
         await prisma.file.deleteMany({

--- a/api/jobs/expired.ts
+++ b/api/jobs/expired.ts
@@ -39,13 +39,20 @@ export const deleteOrphanedFiles = async () => {
         }
 
         // Delete files from disk in parallel for better performance
-        await unlinkFiles(orphanedFiles.map((file) => file.path));
+        const deletedPaths = await unlinkFiles(orphanedFiles.map((file) => file.path));
 
-        // Delete orphaned file records from database
+        // Only drop DB records for files that were actually removed from disk —
+        // failures stay as orphan records so this job retries them next run.
+        const deletedFiles = orphanedFiles.filter((file) => deletedPaths.includes(file.path));
+
+        if (deletedFiles.length === 0) {
+            return;
+        }
+
         await prisma.file.deleteMany({
             where: {
                 id: {
-                    in: orphanedFiles.map((f) => f.id),
+                    in: deletedFiles.map((f) => f.id),
                 },
             },
         });

--- a/api/lib/files.ts
+++ b/api/lib/files.ts
@@ -38,15 +38,20 @@ export async function getMaxFileSize(): Promise<number> {
 
 /**
  * Unlinks files from disk, logging (not throwing) on individual failures —
- * a file may already be gone or inaccessible.
+ * a file may already be gone or inaccessible. Returns the paths that were
+ * actually removed so callers only drop DB records for confirmed deletions.
  */
-export async function unlinkFiles(paths: string[]): Promise<void> {
+export async function unlinkFiles(paths: string[]): Promise<string[]> {
     const results = await Promise.allSettled(paths.map((path) => unlink(path)));
+    const deleted: string[] = [];
     results.forEach((result, index) => {
         if (result.status === 'rejected') {
             console.error(`Failed to delete file from disk: ${paths[index]}`, result.reason);
+        } else {
+            deleted.push(paths[index]);
         }
     });
+    return deleted;
 }
 
 /**

--- a/api/lib/files.ts
+++ b/api/lib/files.ts
@@ -37,8 +37,9 @@ export async function getMaxFileSize(): Promise<number> {
 }
 
 /**
- * Unlinks files from disk, logging (not throwing) on individual failures —
- * a file may already be gone or inaccessible. Returns the paths that were
+ * Unlinks files from disk, logging (not throwing) on individual failures.
+ * A missing file (ENOENT) still counts as removed, since the end state — no
+ * file left on disk — is already achieved. Returns the paths that were
  * actually removed so callers only drop DB records for confirmed deletions.
  */
 export async function unlinkFiles(paths: string[]): Promise<string[]> {
@@ -46,7 +47,11 @@ export async function unlinkFiles(paths: string[]): Promise<string[]> {
     const deleted: string[] = [];
     results.forEach((result, index) => {
         if (result.status === 'rejected') {
-            console.error(`Failed to delete file from disk: ${paths[index]}`, result.reason);
+            if ((result.reason as NodeJS.ErrnoException)?.code === 'ENOENT') {
+                deleted.push(paths[index]);
+            } else {
+                console.error(`Failed to delete file from disk: ${paths[index]}`, result.reason);
+            }
         } else {
             deleted.push(paths[index]);
         }

--- a/api/lib/files.ts
+++ b/api/lib/files.ts
@@ -1,4 +1,4 @@
-import { mkdir } from 'fs/promises';
+import { mkdir, unlink } from 'fs/promises';
 import { basename, join, resolve } from 'path';
 import { FILE } from './constants';
 import { resolveSettings } from './settings';
@@ -34,6 +34,19 @@ export async function getMaxFileSize(): Promise<number> {
     const settings = await resolveSettings();
     const maxSecretSizeKB = settings?.maxSecretSize ?? FILE.DEFAULT_MAX_SIZE_KB;
     return maxSecretSizeKB * 1024; // Convert KB to bytes
+}
+
+/**
+ * Unlinks files from disk, logging (not throwing) on individual failures —
+ * a file may already be gone or inaccessible.
+ */
+export async function unlinkFiles(paths: string[]): Promise<void> {
+    const results = await Promise.allSettled(paths.map((path) => unlink(path)));
+    results.forEach((result, index) => {
+        if (result.status === 'rejected') {
+            console.error(`Failed to delete file from disk: ${paths[index]}`, result.reason);
+        }
+    });
 }
 
 /**

--- a/api/lib/webhook.ts
+++ b/api/lib/webhook.ts
@@ -8,6 +8,7 @@ interface SecretWebhookData {
     hasPassword: boolean;
     hasIpRestriction: boolean;
     viewsRemaining?: number;
+    reason?: string;
 }
 
 interface ApiKeyWebhookData {

--- a/api/routes/secrets.ts
+++ b/api/routes/secrets.ts
@@ -162,12 +162,9 @@ const app = new Hono<{
                                     select: { id: true, path: true },
                                 });
 
-                                if (filesToDelete.length > 0) {
-                                    await tx.file.deleteMany({
-                                        where: { id: { in: filesToDelete.map((f) => f.id) } },
-                                    });
-                                }
-
+                                // Delete the secret only — leave the file records in place
+                                // until disk deletion is confirmed below. Once the secret is
+                                // gone they become orphans that deleteOrphanedFiles retries.
                                 await tx.secrets.delete({ where: { id } });
 
                                 return {
@@ -175,7 +172,7 @@ const app = new Hono<{
                                     status: 401 as const,
                                     burned: true,
                                     ipRange: item.ipRange,
-                                    filesToDelete: filesToDelete.map((f) => f.path),
+                                    filesToDelete,
                                 };
                             }
 
@@ -230,12 +227,24 @@ const app = new Hono<{
                             status: 401 | 404;
                             burned?: boolean;
                             attemptsRemaining?: number;
-                            filesToDelete?: string[];
+                            filesToDelete?: { id: string; path: string }[];
                             ipRange?: string | null;
                         };
 
                     if (filesToDelete && filesToDelete.length > 0) {
-                        await unlinkFiles(filesToDelete);
+                        const deletedPaths = await unlinkFiles(filesToDelete.map((f) => f.path));
+                        const deletedIds = filesToDelete
+                            .filter((f) => deletedPaths.includes(f.path))
+                            .map((f) => f.id);
+
+                        if (deletedIds.length > 0) {
+                            await prisma.file.deleteMany({
+                                where: { id: { in: deletedIds } },
+                            });
+                        }
+                    }
+
+                    if (burned) {
                         sendWebhook('secret.burned', {
                             secretId: id,
                             hasPassword: true,

--- a/api/routes/secrets.ts
+++ b/api/routes/secrets.ts
@@ -2,6 +2,7 @@ import { zValidator } from '@hono/zod-validator';
 import { Hono } from 'hono';
 import { auth } from '../auth';
 import prisma from '../lib/db';
+import { unlinkFiles } from '../lib/files';
 import { compare, hash } from '../lib/password';
 import { buildPaginationMeta } from '../lib/route-utils';
 import { resolveSettings } from '../lib/settings';
@@ -22,6 +23,8 @@ interface SecretCreateData {
     secret: Uint8Array;
     title?: Uint8Array | null;
     password: string | null;
+    limitPasswordAttempts?: boolean | null;
+    maxPasswordAttempts?: number | null;
     expiresAt: Date;
     views?: number;
     isBurnable?: boolean;
@@ -117,6 +120,8 @@ const app = new Hono<{
                             createdAt: true,
                             isBurnable: true,
                             password: true,
+                            limitPasswordAttempts: true,
+                            maxPasswordAttempts: true,
                             salt: true,
                             files: {
                                 select: { id: true, filename: true },
@@ -137,7 +142,48 @@ const app = new Hono<{
                     if (item.password) {
                         const isValidPassword = await compare(data.password!, item.password);
                         if (!isValidPassword) {
-                            return { error: 'Invalid password', status: 401 as const };
+                            if (!item.limitPasswordAttempts) {
+                                return { error: 'Invalid password', status: 401 as const };
+                            }
+
+                            // Atomically increment and read back the counter to avoid a
+                            // read-then-write race under concurrent guess attempts.
+                            const updated = await tx.secrets.update({
+                                where: { id },
+                                data: { failedPasswordAttempts: { increment: 1 } },
+                                select: { failedPasswordAttempts: true },
+                            });
+                            const maxAttempts = item.maxPasswordAttempts ?? 5;
+                            const failedAttempts = updated.failedPasswordAttempts ?? 0;
+
+                            if (failedAttempts >= maxAttempts) {
+                                const filesToDelete = await tx.file.findMany({
+                                    where: { secrets: { some: { id } } },
+                                    select: { id: true, path: true },
+                                });
+
+                                if (filesToDelete.length > 0) {
+                                    await tx.file.deleteMany({
+                                        where: { id: { in: filesToDelete.map((f) => f.id) } },
+                                    });
+                                }
+
+                                await tx.secrets.delete({ where: { id } });
+
+                                return {
+                                    error: 'Secret burned due to too many failed password attempts',
+                                    status: 401 as const,
+                                    burned: true,
+                                    ipRange: item.ipRange,
+                                    filesToDelete: filesToDelete.map((f) => f.path),
+                                };
+                            }
+
+                            return {
+                                error: 'Invalid password',
+                                status: 401 as const,
+                                attemptsRemaining: maxAttempts - failedAttempts,
+                            };
                         }
                     }
 
@@ -178,7 +224,34 @@ const app = new Hono<{
                 });
 
                 if ('error' in result) {
-                    return c.json({ error: result.error }, result.status);
+                    const { error, status, burned, attemptsRemaining, filesToDelete, ipRange } =
+                        result as {
+                            error: string;
+                            status: 401 | 404;
+                            burned?: boolean;
+                            attemptsRemaining?: number;
+                            filesToDelete?: string[];
+                            ipRange?: string | null;
+                        };
+
+                    if (filesToDelete && filesToDelete.length > 0) {
+                        await unlinkFiles(filesToDelete);
+                        sendWebhook('secret.burned', {
+                            secretId: id,
+                            hasPassword: true,
+                            hasIpRestriction: !!ipRange,
+                            reason: 'max_password_attempts_exceeded',
+                        });
+                    }
+
+                    return c.json(
+                        {
+                            error,
+                            ...(burned !== undefined && { burned }),
+                            ...(attemptsRemaining !== undefined && { attemptsRemaining }),
+                        },
+                        status
+                    );
                 }
 
                 return c.json(result);
@@ -250,7 +323,16 @@ const app = new Hono<{
                 return c.json({ error: `Secret exceeds maximum size of ${maxSizeKB} KB` }, 413);
             }
 
-            const { expiresAt, password, fileIds, salt, title, ...rest } = validatedData;
+            const {
+                expiresAt,
+                password,
+                fileIds,
+                salt,
+                title,
+                limitPasswordAttempts,
+                maxPasswordAttempts,
+                ...rest
+            } = validatedData;
 
             const data: SecretCreateData = {
                 ...rest,
@@ -258,6 +340,8 @@ const app = new Hono<{
                 // Title is required by the database, default to empty Uint8Array if not provided
                 title: title ?? new Uint8Array(0),
                 password: password ? await hash(password) : null,
+                limitPasswordAttempts: password ? (limitPasswordAttempts ?? true) : null,
+                maxPasswordAttempts: password ? (maxPasswordAttempts ?? 5) : null,
                 expiresAt: new Date(Date.now() + expiresAt * 1000),
                 ...(fileIds && {
                     files: { connect: fileIds.map((id: string) => ({ id })) },

--- a/api/validations/secrets.ts
+++ b/api/validations/secrets.ts
@@ -34,6 +34,8 @@ const secretSchema = {
         .optional()
         .nullable(),
     password: z.string().optional(),
+    limitPasswordAttempts: z.boolean().default(true).optional(),
+    maxPasswordAttempts: z.number().int().min(1).max(20).optional(),
     expiresAt: z
         .number()
         .refine(

--- a/prisma/migrations/20260820125007_add_password_attempt_limit/migration.sql
+++ b/prisma/migrations/20260820125007_add_password_attempt_limit/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+ALTER TABLE "secrets" ADD COLUMN "failed_password_attempts" INTEGER DEFAULT 0;
+ALTER TABLE "secrets" ADD COLUMN "limit_password_attempts" BOOLEAN DEFAULT true;
+ALTER TABLE "secrets" ADD COLUMN "max_password_attempts" INTEGER DEFAULT 5;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,20 +8,23 @@ generator client {
 }
 
 model Secrets {
-    id            String         @id @default(uuid())
-    secret        Bytes
-    title         Bytes
-    views         Int?           @default(1)
-    password      String?
-    salt          String
-    isBurnable    Boolean?       @default(false) @map("is_burnable")
-    createdAt     DateTime       @default(now()) @map("created_at")
-    expiresAt     DateTime       @map("expires_at")
-    ipRange       String?        @default("") @map("ip_range")
-    userId        String?
-    user          User?          @relation(fields: [userId], references: [id])
-    files         File[]         @relation
-    secretRequest SecretRequest?
+    id                     String         @id @default(uuid())
+    secret                 Bytes
+    title                  Bytes
+    views                  Int?           @default(1)
+    password               String?
+    limitPasswordAttempts  Boolean?       @default(true) @map("limit_password_attempts")
+    maxPasswordAttempts    Int?           @default(5) @map("max_password_attempts")
+    failedPasswordAttempts Int?           @default(0) @map("failed_password_attempts")
+    salt                   String
+    isBurnable             Boolean?       @default(false) @map("is_burnable")
+    createdAt              DateTime       @default(now()) @map("created_at")
+    expiresAt              DateTime       @map("expires_at")
+    ipRange                String?        @default("") @map("ip_range")
+    userId                 String?
+    user                   User?          @relation(fields: [userId], references: [id])
+    files                  File[]         @relation
+    secretRequest          SecretRequest?
 
     @@index([expiresAt])
     @@index([userId])

--- a/src/components/SecretForm.tsx
+++ b/src/components/SecretForm.tsx
@@ -20,6 +20,8 @@ export function SecretForm() {
         views,
         isBurnable,
         ipRange,
+        limitPasswordAttempts,
+        maxPasswordAttempts,
         setSecretIdAndKeys,
         setSecretData,
     } = useSecretStore();
@@ -81,6 +83,7 @@ export function SecretForm() {
             title: encryptedTitle,
             salt,
             password: password ? encryptionKey : '',
+            ...(password && { limitPasswordAttempts, maxPasswordAttempts }),
             expiresAt,
             views,
             isBurnable,

--- a/src/components/SecuritySettings.tsx
+++ b/src/components/SecuritySettings.tsx
@@ -10,7 +10,16 @@ import { ToggleSwitch } from './ToggleSwitch';
 import { ViewsSlider } from './ViewsSlider';
 
 export function SecuritySettings() {
-    const { expiresAt, views, isBurnable, password, ipRange, setSecretData } = useSecretStore();
+    const {
+        expiresAt,
+        views,
+        isBurnable,
+        password,
+        ipRange,
+        limitPasswordAttempts,
+        maxPasswordAttempts,
+        setSecretData,
+    } = useSecretStore();
     const { saveSettings, setSaveSettings, updateSettings } = useSecretSettingsStore();
     const { settings: instanceSettings } = useHemmeligStore();
     const { t } = useTranslation();
@@ -174,6 +183,56 @@ export function SecuritySettings() {
                                             {t('security_settings.password_hint')}
                                         </p>
                                     )}
+
+                                    <div className="mt-4 pt-4 border-t border-gray-200 dark:border-dark-500/50">
+                                        <div className="flex items-center justify-between">
+                                            <span className="text-xs font-medium text-gray-700 dark:text-slate-200">
+                                                {t(
+                                                    'security_settings.limit_password_attempts_title'
+                                                )}
+                                            </span>
+                                            <ToggleSwitch
+                                                checked={limitPasswordAttempts}
+                                                onChange={(val) =>
+                                                    setSecretData({ limitPasswordAttempts: val })
+                                                }
+                                            />
+                                        </div>
+                                        <p className="text-xs text-gray-500 dark:text-slate-400 mt-2">
+                                            {t(
+                                                'security_settings.limit_password_attempts_description'
+                                            )}
+                                        </p>
+
+                                        {limitPasswordAttempts && (
+                                            <div className="mt-3">
+                                                <label className="block text-xs text-gray-500 dark:text-slate-400 mb-2">
+                                                    {t('security_settings.max_attempts_label')}
+                                                </label>
+                                                <input
+                                                    type="number"
+                                                    min={1}
+                                                    max={20}
+                                                    value={maxPasswordAttempts}
+                                                    onChange={(e) =>
+                                                        setSecretData({
+                                                            maxPasswordAttempts: Math.min(
+                                                                20,
+                                                                Math.max(
+                                                                    1,
+                                                                    Number(e.target.value) || 1
+                                                                )
+                                                            ),
+                                                        })
+                                                    }
+                                                    className="w-24 px-3 py-2 bg-white dark:bg-dark-600 border border-gray-300 dark:border-dark-500 text-gray-900 dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-blue-500/30 focus:border-blue-500 transition-all duration-200 text-sm"
+                                                />
+                                                <p className="text-xs text-gray-500 dark:text-slate-400 mt-2">
+                                                    {t('security_settings.max_attempts_hint')}
+                                                </p>
+                                            </div>
+                                        )}
+                                    </div>
                                 </div>
                             )}
                         </div>

--- a/src/components/SecuritySettings.tsx
+++ b/src/components/SecuritySettings.tsx
@@ -206,10 +206,14 @@ export function SecuritySettings() {
 
                                         {limitPasswordAttempts && (
                                             <div className="mt-3">
-                                                <label className="block text-xs text-gray-500 dark:text-slate-400 mb-2">
+                                                <label
+                                                    htmlFor="max-password-attempts"
+                                                    className="block text-xs text-gray-500 dark:text-slate-400 mb-2"
+                                                >
                                                     {t('security_settings.max_attempts_label')}
                                                 </label>
                                                 <input
+                                                    id="max-password-attempts"
                                                     type="number"
                                                     min={1}
                                                     max={20}

--- a/src/i18n/locales/da/da.json
+++ b/src/i18n/locales/da/da.json
@@ -142,7 +142,11 @@
         "ip_address_cidr_placeholder": "192.168.1.0/24 eller 203.0.113.5",
         "ip_address_cidr_hint": "Kun anmodninger fra disse IP-adresser vil kunne få adgang til hemmeligheden",
         "burn_after_time_title": "Brænd efter tiden udløber",
-        "burn_after_time_description": "Brænd kun hemmeligheden efter tiden udløber"
+        "burn_after_time_description": "Brænd kun hemmeligheden efter tiden udløber",
+        "limit_password_attempts_title": "Begræns antal adgangskodeforsøg",
+        "limit_password_attempts_description": "Brænd automatisk hemmeligheden og dens vedhæftede filer efter for mange forkerte adgangskodeforsøg",
+        "max_attempts_label": "Maks. forsøg",
+        "max_attempts_hint": "Hemmeligheden vil blive permanent destrueret efter dette antal forkerte forsøg (1-20)"
     },
     "title_field": {
         "placeholder": "Titel",
@@ -618,7 +622,11 @@
         "delete_modal_title": "Slet hemmelighed",
         "delete_modal_message": "Er du sikker på, at du vil slette denne hemmelighed? Denne handling kan ikke fortrydes.",
         "decryption_failed": "Kunne ikke dekryptere hemmeligheden. Tjek venligst din adgangskode eller dekrypteringsnøgle.",
-        "fetch_error": "Der opstod en fejl ved hentning af hemmeligheden. Prøv venligst igen."
+        "fetch_error": "Der opstod en fejl ved hentning af hemmeligheden. Prøv venligst igen.",
+        "invalid_password": "Forkert adgangskode. Prøv venligst igen.",
+        "invalid_password_one_attempt_remaining": "Forkert adgangskode. 1 forsøg tilbage, før denne hemmelighed destrueres.",
+        "invalid_password_attempts_remaining": "Forkert adgangskode. {{count}} forsøg tilbage, før denne hemmelighed destrueres.",
+        "secret_burned_attempts_exceeded": "Denne hemmelighed er blevet permanent destrueret efter for mange forkerte adgangskodeforsøg."
     },
     "expiration": {
         "28_days": "28 dage",

--- a/src/i18n/locales/de/de.json
+++ b/src/i18n/locales/de/de.json
@@ -142,7 +142,11 @@
         "ip_address_cidr_placeholder": "192.168.1.0/24 oder 203.0.113.5",
         "ip_address_cidr_hint": "Nur Anfragen von diesen IP-Adressen können auf das Geheimnis zugreifen",
         "burn_after_time_title": "Nach Zeitablauf vernichten",
-        "burn_after_time_description": "Das Geheimnis erst nach Ablauf der Zeit vernichten"
+        "burn_after_time_description": "Das Geheimnis erst nach Ablauf der Zeit vernichten",
+        "limit_password_attempts_title": "Passwortversuche begrenzen",
+        "limit_password_attempts_description": "Das Geheimnis und die angehängten Dateien nach zu vielen falschen Passwortversuchen automatisch vernichten",
+        "max_attempts_label": "Max. Versuche",
+        "max_attempts_hint": "Das Geheimnis wird nach dieser Anzahl falscher Versuche dauerhaft vernichtet (1-20)"
     },
     "title_field": {
         "placeholder": "Titel",
@@ -618,7 +622,11 @@
         "delete_modal_title": "Geheimnis löschen",
         "delete_modal_message": "Sind Sie sicher, dass Sie dieses Geheimnis löschen möchten? Diese Aktion kann nicht rückgängig gemacht werden.",
         "decryption_failed": "Das Geheimnis konnte nicht entschlüsselt werden. Bitte überprüfen Sie Ihr Passwort oder den Entschlüsselungsschlüssel.",
-        "fetch_error": "Beim Abrufen des Geheimnisses ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut."
+        "fetch_error": "Beim Abrufen des Geheimnisses ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut.",
+        "invalid_password": "Falsches Passwort. Bitte versuchen Sie es erneut.",
+        "invalid_password_one_attempt_remaining": "Falsches Passwort. Noch 1 Versuch übrig, bevor dieses Geheimnis vernichtet wird.",
+        "invalid_password_attempts_remaining": "Falsches Passwort. Noch {{count}} Versuche übrig, bevor dieses Geheimnis vernichtet wird.",
+        "secret_burned_attempts_exceeded": "Dieses Geheimnis wurde nach zu vielen falschen Passwortversuchen dauerhaft vernichtet."
     },
     "expiration": {
         "28_days": "28 Tage",

--- a/src/i18n/locales/en/en.json
+++ b/src/i18n/locales/en/en.json
@@ -142,7 +142,11 @@
         "ip_address_cidr_placeholder": "192.168.1.0/24 or 203.0.113.5",
         "ip_address_cidr_hint": "Only requests from these IP addresses will be able to access the secret",
         "burn_after_time_title": "Burn after time expires",
-        "burn_after_time_description": "Burn the secret only after the time expires"
+        "burn_after_time_description": "Burn the secret only after the time expires",
+        "limit_password_attempts_title": "Limit Password Attempts",
+        "limit_password_attempts_description": "Automatically burn the secret and its attached files after too many incorrect password attempts",
+        "max_attempts_label": "Max Attempts",
+        "max_attempts_hint": "The secret will be permanently destroyed after this many incorrect attempts (1-20)"
     },
     "title_field": {
         "placeholder": "Title",
@@ -619,7 +623,11 @@
         "delete_modal_title": "Delete Secret",
         "delete_modal_message": "Are you sure you want to delete this secret? This action cannot be undone.",
         "decryption_failed": "Failed to decrypt the secret. Please check your password or decryption key.",
-        "fetch_error": "An error occurred while fetching the secret. Please try again."
+        "fetch_error": "An error occurred while fetching the secret. Please try again.",
+        "invalid_password": "Incorrect password. Please try again.",
+        "invalid_password_one_attempt_remaining": "Incorrect password. 1 attempt remaining before this secret is destroyed.",
+        "invalid_password_attempts_remaining": "Incorrect password. {{count}} attempts remaining before this secret is destroyed.",
+        "secret_burned_attempts_exceeded": "This secret has been permanently destroyed after too many incorrect password attempts."
     },
     "expiration": {
         "28_days": "28 Days",

--- a/src/i18n/locales/es/es.json
+++ b/src/i18n/locales/es/es.json
@@ -142,7 +142,11 @@
         "ip_address_cidr_placeholder": "192.168.1.0/24 o 203.0.113.5",
         "ip_address_cidr_hint": "Solo las solicitudes de estas direcciones IP podrán acceder al secreto",
         "burn_after_time_title": "Autodestrucción al expirar el tiempo",
-        "burn_after_time_description": "Quemar el secreto solo después de que expire el tiempo"
+        "burn_after_time_description": "Quemar el secreto solo después de que expire el tiempo",
+        "limit_password_attempts_title": "Limitar intentos de contraseña",
+        "limit_password_attempts_description": "Quemar automáticamente el secreto y sus archivos adjuntos tras demasiados intentos de contraseña incorrectos",
+        "max_attempts_label": "Intentos máximos",
+        "max_attempts_hint": "El secreto se destruirá permanentemente después de este número de intentos incorrectos (1-20)"
     },
     "title_field": {
         "placeholder": "Título",
@@ -618,7 +622,11 @@
         "delete_modal_title": "Eliminar secreto",
         "delete_modal_message": "¿Estás seguro de que quieres eliminar este secreto? Esta acción no se puede deshacer.",
         "decryption_failed": "No se pudo descifrar el secreto. Por favor, verifica tu contraseña o clave de descifrado.",
-        "fetch_error": "Ocurrió un error al obtener el secreto. Por favor, inténtalo de nuevo."
+        "fetch_error": "Ocurrió un error al obtener el secreto. Por favor, inténtalo de nuevo.",
+        "invalid_password": "Contraseña incorrecta. Por favor, inténtalo de nuevo.",
+        "invalid_password_one_attempt_remaining": "Contraseña incorrecta. Queda 1 intento antes de que este secreto se destruya.",
+        "invalid_password_attempts_remaining": "Contraseña incorrecta. Quedan {{count}} intentos antes de que este secreto se destruya.",
+        "secret_burned_attempts_exceeded": "Este secreto ha sido destruido permanentemente tras demasiados intentos de contraseña incorrectos."
     },
     "expiration": {
         "28_days": "28 Días",

--- a/src/i18n/locales/fr/fr.json
+++ b/src/i18n/locales/fr/fr.json
@@ -142,7 +142,11 @@
         "ip_address_cidr_placeholder": "192.168.1.0/24 ou 203.0.113.5",
         "ip_address_cidr_hint": "Seules les requêtes provenant de ces adresses IP pourront accéder au secret",
         "burn_after_time_title": "Détruire après expiration",
-        "burn_after_time_description": "Détruire le secret uniquement après l'expiration du délai"
+        "burn_after_time_description": "Détruire le secret uniquement après l'expiration du délai",
+        "limit_password_attempts_title": "Limiter les tentatives de mot de passe",
+        "limit_password_attempts_description": "Détruire automatiquement le secret et ses fichiers joints après trop de tentatives de mot de passe incorrectes",
+        "max_attempts_label": "Tentatives maximales",
+        "max_attempts_hint": "Le secret sera définitivement détruit après ce nombre de tentatives incorrectes (1-20)"
     },
     "title_field": {
         "placeholder": "Titre",
@@ -618,7 +622,11 @@
         "delete_modal_title": "Supprimer le secret",
         "delete_modal_message": "Êtes-vous sûr de vouloir supprimer ce secret ? Cette action est irréversible.",
         "decryption_failed": "Échec du déchiffrement du secret. Veuillez vérifier votre mot de passe ou votre clé de déchiffrement.",
-        "fetch_error": "Une erreur s'est produite lors de la récupération du secret. Veuillez réessayer."
+        "fetch_error": "Une erreur s'est produite lors de la récupération du secret. Veuillez réessayer.",
+        "invalid_password": "Mot de passe incorrect. Veuillez réessayer.",
+        "invalid_password_one_attempt_remaining": "Mot de passe incorrect. Il reste 1 tentative avant que ce secret ne soit détruit.",
+        "invalid_password_attempts_remaining": "Mot de passe incorrect. Il reste {{count}} tentatives avant que ce secret ne soit détruit.",
+        "secret_burned_attempts_exceeded": "Ce secret a été définitivement détruit après trop de tentatives de mot de passe incorrectes."
     },
     "expiration": {
         "28_days": "28 Jours",

--- a/src/i18n/locales/it/it.json
+++ b/src/i18n/locales/it/it.json
@@ -142,7 +142,11 @@
         "ip_address_cidr_placeholder": "192.168.1.0/24 o 203.0.113.5",
         "ip_address_cidr_hint": "Solo le richieste da questi indirizzi IP potranno accedere al segreto",
         "burn_after_time_title": "Distruggi dopo la scadenza",
-        "burn_after_time_description": "Distruggi il segreto solo dopo la scadenza del tempo"
+        "burn_after_time_description": "Distruggi il segreto solo dopo la scadenza del tempo",
+        "limit_password_attempts_title": "Limita i tentativi di password",
+        "limit_password_attempts_description": "Distruggi automaticamente il segreto e i file allegati dopo troppi tentativi di password errati",
+        "max_attempts_label": "Tentativi massimi",
+        "max_attempts_hint": "Il segreto verrà distrutto definitivamente dopo questo numero di tentativi errati (1-20)"
     },
     "title_field": {
         "placeholder": "Titolo",
@@ -618,7 +622,11 @@
         "delete_modal_title": "Elimina segreto",
         "delete_modal_message": "Sei sicuro di voler eliminare questo segreto? Questa azione non può essere annullata.",
         "decryption_failed": "Impossibile decifrare il segreto. Verifica la tua password o la chiave di decrittazione.",
-        "fetch_error": "Si è verificato un errore durante il recupero del segreto. Riprova."
+        "fetch_error": "Si è verificato un errore durante il recupero del segreto. Riprova.",
+        "invalid_password": "Password errata. Riprova.",
+        "invalid_password_one_attempt_remaining": "Password errata. Rimane 1 tentativo prima che questo segreto venga distrutto.",
+        "invalid_password_attempts_remaining": "Password errata. Rimangono {{count}} tentativi prima che questo segreto venga distrutto.",
+        "secret_burned_attempts_exceeded": "Questo segreto è stato distrutto definitivamente dopo troppi tentativi di password errati."
     },
     "expiration": {
         "28_days": "28 Giorni",

--- a/src/i18n/locales/nl/nl.json
+++ b/src/i18n/locales/nl/nl.json
@@ -142,7 +142,11 @@
         "ip_address_cidr_placeholder": "192.168.1.0/24 of 203.0.113.5",
         "ip_address_cidr_hint": "Alleen verzoeken van deze IP-adressen hebben toegang tot het geheim",
         "burn_after_time_title": "Vernietigen na het verlopen van de tijd",
-        "burn_after_time_description": "Vernietig het geheim pas nadat de tijd is verstreken"
+        "burn_after_time_description": "Vernietig het geheim pas nadat de tijd is verstreken",
+        "limit_password_attempts_title": "Wachtwoordpogingen beperken",
+        "limit_password_attempts_description": "Vernietig het geheim en de bijgevoegde bestanden automatisch na te veel onjuiste wachtwoordpogingen",
+        "max_attempts_label": "Max. pogingen",
+        "max_attempts_hint": "Het geheim wordt permanent vernietigd na dit aantal onjuiste pogingen (1-20)"
     },
     "title_field": {
         "placeholder": "Titel",
@@ -619,7 +623,11 @@
         "delete_modal_title": "Geheim verwijderen",
         "delete_modal_message": "Weet je zeker dat je dit geheim wilt verwijderen? Deze actie kan niet ongedaan worden gemaakt.",
         "decryption_failed": "Het ontsleutelen van het geheim is mislukt. Controleer je wachtwoord en decryptiesleutel.",
-        "fetch_error": "Er is een fout opgetreden tijdens het ophalen van het geheim. Probeer het opnieuw."
+        "fetch_error": "Er is een fout opgetreden tijdens het ophalen van het geheim. Probeer het opnieuw.",
+        "invalid_password": "Onjuist wachtwoord. Probeer het opnieuw.",
+        "invalid_password_one_attempt_remaining": "Onjuist wachtwoord. Nog 1 poging over voordat dit geheim wordt vernietigd.",
+        "invalid_password_attempts_remaining": "Onjuist wachtwoord. Nog {{count}} pogingen over voordat dit geheim wordt vernietigd.",
+        "secret_burned_attempts_exceeded": "Dit geheim is permanent vernietigd na te veel onjuiste wachtwoordpogingen."
     },
     "expiration": {
         "28_days": "28 dagen",

--- a/src/i18n/locales/no/no.json
+++ b/src/i18n/locales/no/no.json
@@ -142,7 +142,11 @@
         "ip_address_cidr_placeholder": "192.168.1.0/24 eller 203.0.113.5",
         "ip_address_cidr_hint": "Kun forespørsler fra disse IP-adressene vil kunne få tilgang til hemmeligheten",
         "burn_after_time_title": "Brenn etter at tiden utløper",
-        "burn_after_time_description": "Brenn hemmeligheten kun etter at tiden utløper"
+        "burn_after_time_description": "Brenn hemmeligheten kun etter at tiden utløper",
+        "limit_password_attempts_title": "Begrens antall passordforsøk",
+        "limit_password_attempts_description": "Brenn automatisk hemmeligheten og vedlagte filer etter for mange feil passordforsøk",
+        "max_attempts_label": "Maks. forsøk",
+        "max_attempts_hint": "Hemmeligheten vil bli permanent ødelagt etter dette antallet feilforsøk (1-20)"
     },
     "title_field": {
         "placeholder": "Tittel",
@@ -618,7 +622,11 @@
         "delete_modal_title": "Slett hemmelighet",
         "delete_modal_message": "Er du sikker på at du vil slette denne hemmeligheten? Denne handlingen kan ikke angres.",
         "decryption_failed": "Kunne ikke dekryptere hemmeligheten. Vennligst sjekk passordet eller dekrypteringsnøkkelen din.",
-        "fetch_error": "En feil oppstod under henting av hemmeligheten. Vennligst prøv igjen."
+        "fetch_error": "En feil oppstod under henting av hemmeligheten. Vennligst prøv igjen.",
+        "invalid_password": "Feil passord. Vennligst prøv igjen.",
+        "invalid_password_one_attempt_remaining": "Feil passord. 1 forsøk igjen før denne hemmeligheten ødelegges.",
+        "invalid_password_attempts_remaining": "Feil passord. {{count}} forsøk igjen før denne hemmeligheten ødelegges.",
+        "secret_burned_attempts_exceeded": "Denne hemmeligheten har blitt permanent ødelagt etter for mange feil passordforsøk."
     },
     "expiration": {
         "28_days": "28 dager",

--- a/src/i18n/locales/sv/sv.json
+++ b/src/i18n/locales/sv/sv.json
@@ -142,7 +142,11 @@
         "ip_address_cidr_placeholder": "192.168.1.0/24 eller 203.0.113.5",
         "ip_address_cidr_hint": "Endast förfrågningar från dessa IP-adresser kommer att kunna komma åt hemligheten",
         "burn_after_time_title": "Bränn efter att tiden går ut",
-        "burn_after_time_description": "Bränn hemligheten endast efter att tiden går ut"
+        "burn_after_time_description": "Bränn hemligheten endast efter att tiden går ut",
+        "limit_password_attempts_title": "Begränsa lösenordsförsök",
+        "limit_password_attempts_description": "Bränn automatiskt hemligheten och dess bifogade filer efter för många felaktiga lösenordsförsök",
+        "max_attempts_label": "Max antal försök",
+        "max_attempts_hint": "Hemligheten kommer att förstöras permanent efter detta antal felaktiga försök (1-20)"
     },
     "title_field": {
         "placeholder": "Titel",
@@ -618,7 +622,11 @@
         "delete_modal_title": "Ta bort hemlighet",
         "delete_modal_message": "Är du säker på att du vill ta bort denna hemlighet? Denna åtgärd kan inte ångras.",
         "decryption_failed": "Misslyckades med att dekryptera hemligheten. Kontrollera ditt lösenord eller dekrypteringsnyckel.",
-        "fetch_error": "Ett fel inträffade vid hämtning av hemligheten. Försök igen."
+        "fetch_error": "Ett fel inträffade vid hämtning av hemligheten. Försök igen.",
+        "invalid_password": "Fel lösenord. Försök igen.",
+        "invalid_password_one_attempt_remaining": "Fel lösenord. 1 försök kvar innan denna hemlighet förstörs.",
+        "invalid_password_attempts_remaining": "Fel lösenord. {{count}} försök kvar innan denna hemlighet förstörs.",
+        "secret_burned_attempts_exceeded": "Denna hemlighet har permanent förstörts efter för många felaktiga lösenordsförsök."
     },
     "expiration": {
         "28_days": "28 dagar",

--- a/src/i18n/locales/zh/zh.json
+++ b/src/i18n/locales/zh/zh.json
@@ -142,7 +142,11 @@
         "ip_address_cidr_placeholder": "192.168.1.0/24 或 203.0.113.5",
         "ip_address_cidr_hint": "只有来自这些 IP 地址的请求才能访问秘密",
         "burn_after_time_title": "过期后销毁",
-        "burn_after_time_description": "仅在时间到期后销毁秘密"
+        "burn_after_time_description": "仅在时间到期后销毁秘密",
+        "limit_password_attempts_title": "限制密码尝试次数",
+        "limit_password_attempts_description": "在密码错误尝试次数过多后自动销毁该秘密及其附件",
+        "max_attempts_label": "最大尝试次数",
+        "max_attempts_hint": "在达到此错误尝试次数后，该秘密将被永久销毁（1-20）"
     },
     "title_field": {
         "placeholder": "标题",
@@ -618,7 +622,11 @@
         "delete_modal_title": "删除秘密",
         "delete_modal_message": "您确定要删除此秘密吗？此操作无法撤消。",
         "decryption_failed": "解密秘密失败。请检查您的密码或解密密钥。",
-        "fetch_error": "获取秘密时发生错误。请重试。"
+        "fetch_error": "获取秘密时发生错误。请重试。",
+        "invalid_password": "密码错误，请重试。",
+        "invalid_password_one_attempt_remaining": "密码错误。还剩 1 次尝试机会，之后该秘密将被销毁。",
+        "invalid_password_attempts_remaining": "密码错误。还剩 {{count}} 次尝试机会，之后该秘密将被销毁。",
+        "secret_burned_attempts_exceeded": "由于密码错误尝试次数过多，该秘密已被永久销毁。"
     },
     "expiration": {
         "28_days": "28 天",

--- a/src/pages/SecretPage.tsx
+++ b/src/pages/SecretPage.tsx
@@ -18,7 +18,7 @@ import { Card } from '../components/Card';
 import Editor from '../components/Editor';
 import { Modal } from '../components/Modal';
 import { useCopyFeedback } from '../hooks/useCopyFeedback';
-import { api } from '../lib/api';
+import { api, apiRaw } from '../lib/api';
 import { decrypt, decryptFile, generateEncryptionKey } from '../lib/crypto';
 
 interface SecretFile {
@@ -53,6 +53,7 @@ export function SecretPage() {
     const [isDeleting, setIsDeleting] = useState(false);
     const [decryptionError, setDecryptionError] = useState<string | null>(null);
     const [isBurnable, setIsBurnable] = useState(false);
+    const [isBurnedByAttempts, setIsBurnedByAttempts] = useState(false);
 
     const decryptionKeyFromUrl = location.hash.startsWith('#decryptionKey=')
         ? location.hash.substring('#decryptionKey='.length)
@@ -72,7 +73,7 @@ export function SecretPage() {
                 const finalDecryptionKey = password
                     ? generateEncryptionKey(password)
                     : decryptionKey;
-                const response = await api.secrets[':id'].$post({
+                const response = await apiRaw.secrets[':id'].$post({
                     param: { id: id! },
                     json: { password: finalDecryptionKey },
                 });
@@ -105,6 +106,26 @@ export function SecretPage() {
                     if ('views' in data) {
                         setViewsRemaining(data.views);
                     }
+                } else if (response.status === 401) {
+                    if ('burned' in data && data.burned) {
+                        setIsBurnedByAttempts(true);
+                        setDecryptionError(t('secret_page.secret_burned_attempts_exceeded'));
+                    } else if (
+                        'attemptsRemaining' in data &&
+                        typeof data.attemptsRemaining === 'number'
+                    ) {
+                        setDecryptionError(
+                            data.attemptsRemaining === 1
+                                ? t('secret_page.invalid_password_one_attempt_remaining')
+                                : t('secret_page.invalid_password_attempts_remaining', {
+                                      count: data.attemptsRemaining,
+                                  })
+                        );
+                    } else {
+                        setDecryptionError(t('secret_page.invalid_password'));
+                    }
+                } else {
+                    setDecryptionError(t('secret_page.fetch_error'));
                 }
             } catch (err: unknown) {
                 console.error('Error fetching secret:', err);
@@ -227,57 +248,75 @@ export function SecretPage() {
 
                         {/* Overlay */}
                         <div className="absolute inset-0 bg-white/90 dark:bg-dark-800/90 backdrop-blur-[2px] flex flex-col items-center justify-center p-6">
-                            {needsManualKeyEntry && (
-                                <div className="w-full max-w-xs mb-5">
-                                    <label className="block text-sm font-medium text-gray-600 dark:text-slate-300 mb-2 text-center">
-                                        {t('secret_page.decryption_key_label')}
-                                    </label>
-                                    <input
-                                        type="text"
-                                        value={decryptionKeyInput}
-                                        onChange={(e) => setDecryptionKeyInput(e.target.value)}
-                                        onKeyDown={(e) => e.key === 'Enter' && handleViewSecret()}
-                                        className="w-full px-4 py-3 bg-gray-50 dark:bg-dark-700 border border-gray-200 dark:border-dark-500 text-gray-900 dark:text-slate-100 placeholder-gray-400 dark:placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-teal-500/30 focus:border-teal-500 transition-all duration-200 text-center font-mono text-sm"
-                                        placeholder={t('secret_page.decryption_key_placeholder')}
-                                        autoFocus
-                                    />
-                                </div>
-                            )}
-
-                            {isPasswordProtected && (
-                                <div className="w-full max-w-xs mb-5">
-                                    <input
-                                        type="password"
-                                        value={passwordInput}
-                                        onChange={(e) => setPasswordInput(e.target.value)}
-                                        onKeyDown={(e) => e.key === 'Enter' && handleViewSecret()}
-                                        className="w-full px-4 py-3 bg-gray-50 dark:bg-dark-700 border border-gray-200 dark:border-dark-500 text-gray-900 dark:text-slate-100 placeholder-gray-400 dark:placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-teal-500/30 focus:border-teal-500 transition-all duration-200 text-center"
-                                        placeholder={t('secret_page.password_placeholder')}
-                                        autoFocus={!needsManualKeyEntry}
-                                    />
-                                </div>
-                            )}
-
-                            <button
-                                onClick={handleViewSecret}
-                                disabled={needsManualKeyEntry && !decryptionKeyInput}
-                                className="inline-flex items-center gap-2 px-8 py-3 bg-teal-500 hover:bg-teal-600 disabled:bg-gray-400 disabled:cursor-not-allowed text-white font-semibold transition-all duration-200"
-                            >
-                                <LockOpen className="w-5 h-5" />
-                                {t('secret_page.unlock_secret')}
-                            </button>
-
-                            {decryptionError && (
-                                <p className="text-sm text-red-500 mt-4 text-center">
+                            {isBurnedByAttempts ? (
+                                <p className="text-sm text-red-500 text-center max-w-xs">
                                     {decryptionError}
                                 </p>
-                            )}
+                            ) : (
+                                <>
+                                    {needsManualKeyEntry && (
+                                        <div className="w-full max-w-xs mb-5">
+                                            <label className="block text-sm font-medium text-gray-600 dark:text-slate-300 mb-2 text-center">
+                                                {t('secret_page.decryption_key_label')}
+                                            </label>
+                                            <input
+                                                type="text"
+                                                value={decryptionKeyInput}
+                                                onChange={(e) =>
+                                                    setDecryptionKeyInput(e.target.value)
+                                                }
+                                                onKeyDown={(e) =>
+                                                    e.key === 'Enter' && handleViewSecret()
+                                                }
+                                                className="w-full px-4 py-3 bg-gray-50 dark:bg-dark-700 border border-gray-200 dark:border-dark-500 text-gray-900 dark:text-slate-100 placeholder-gray-400 dark:placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-teal-500/30 focus:border-teal-500 transition-all duration-200 text-center font-mono text-sm"
+                                                placeholder={t(
+                                                    'secret_page.decryption_key_placeholder'
+                                                )}
+                                                autoFocus
+                                            />
+                                        </div>
+                                    )}
 
-                            <p className="text-xs text-gray-500 dark:text-slate-400 mt-5 text-center">
-                                {viewsRemaining === 1
-                                    ? t('secret_page.one_view_remaining')
-                                    : t('secret_page.views_remaining', { count: viewsRemaining })}
-                            </p>
+                                    {isPasswordProtected && (
+                                        <div className="w-full max-w-xs mb-5">
+                                            <input
+                                                type="password"
+                                                value={passwordInput}
+                                                onChange={(e) => setPasswordInput(e.target.value)}
+                                                onKeyDown={(e) =>
+                                                    e.key === 'Enter' && handleViewSecret()
+                                                }
+                                                className="w-full px-4 py-3 bg-gray-50 dark:bg-dark-700 border border-gray-200 dark:border-dark-500 text-gray-900 dark:text-slate-100 placeholder-gray-400 dark:placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-teal-500/30 focus:border-teal-500 transition-all duration-200 text-center"
+                                                placeholder={t('secret_page.password_placeholder')}
+                                                autoFocus={!needsManualKeyEntry}
+                                            />
+                                        </div>
+                                    )}
+
+                                    <button
+                                        onClick={handleViewSecret}
+                                        disabled={needsManualKeyEntry && !decryptionKeyInput}
+                                        className="inline-flex items-center gap-2 px-8 py-3 bg-teal-500 hover:bg-teal-600 disabled:bg-gray-400 disabled:cursor-not-allowed text-white font-semibold transition-all duration-200"
+                                    >
+                                        <LockOpen className="w-5 h-5" />
+                                        {t('secret_page.unlock_secret')}
+                                    </button>
+
+                                    {decryptionError && (
+                                        <p className="text-sm text-red-500 mt-4 text-center">
+                                            {decryptionError}
+                                        </p>
+                                    )}
+
+                                    <p className="text-xs text-gray-500 dark:text-slate-400 mt-5 text-center">
+                                        {viewsRemaining === 1
+                                            ? t('secret_page.one_view_remaining')
+                                            : t('secret_page.views_remaining', {
+                                                  count: viewsRemaining,
+                                              })}
+                                    </p>
+                                </>
+                            )}
                         </div>
                     </div>
                 </Card>

--- a/src/store/secretStore.ts
+++ b/src/store/secretStore.ts
@@ -17,6 +17,8 @@ interface SecretState {
     views: number;
     isBurnable: boolean;
     ipRange: string | null;
+    limitPasswordAttempts: boolean;
+    maxPasswordAttempts: number;
     setSecretIdAndKeys: (
         secretId: string | null,
         decryptionKey: string | null,
@@ -24,7 +26,18 @@ interface SecretState {
     ) => void;
     setSecretData: (
         data: Partial<
-            Pick<SecretState, 'secret' | 'title' | 'expiresAt' | 'views' | 'isBurnable' | 'ipRange'>
+            Pick<
+                SecretState,
+                | 'secret'
+                | 'title'
+                | 'expiresAt'
+                | 'views'
+                | 'isBurnable'
+                | 'ipRange'
+                | 'password'
+                | 'limitPasswordAttempts'
+                | 'maxPasswordAttempts'
+            >
         >
     ) => void;
     resetSecret: () => void;
@@ -49,6 +62,8 @@ const defaultState = {
     views: 1,
     isBurnable: false,
     ipRange: null,
+    limitPasswordAttempts: true,
+    maxPasswordAttempts: 5,
 };
 
 export const useSecretStore = create<SecretState>((set) => ({


### PR DESCRIPTION
**Descrription**
To prevent brute force attacks on secret's and extra option was added to burn a secret after x amount of failed attempts.
The default has been set to 5, this feature is optional but on by default currently

**Issue 512**
When looking to improve protection from brute force attacks I looked at the suggestion in this issue:
https://github.com/HemmeligOrg/Hemmelig.app/issues/512 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable password-attempt limits for protected secrets, allowing 1–20 attempts.
  - Shows remaining attempts after incorrect passwords.
  - Automatically destroys secrets after exceeding the configured limit.
  - Displays distinct messages for invalid passwords and permanently destroyed secrets.
- **Localization**
  - Added translations for password-attempt protection and secret access messages across supported languages.
- **Bug Fixes**
  - Improved cleanup of files associated with expired or destroyed secrets, retrying records when deletion fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->