### PR TITLE
fix(auth): upgrade Better Auth to 1.6.30

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
                 "@prisma/client": "^7.4.1",
                 "@tailwindcss/vite": "^4.1.18",
                 "argon2": "^0.44.0",
-                "better-auth": "^1.4.6",
+                "better-auth": "1.6.30",
                 "better-sqlite3": "^12.5.0",
                 "croner": "^9.1.0",
                 "dlv": "^1.1.3",
@@ -371,38 +371,43 @@
             }
         },
         "node_modules/@better-auth/core": {
-            "version": "1.5.5",
-            "resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.5.5.tgz",
-            "integrity": "sha512-1oR/2jAp821Dcf67kQYHUoyNcdc1TcShfw4QMK0YTVntuRES5mUOyvEJql5T6eIuLfaqaN4LOF78l0FtF66HXA==",
+            "version": "1.6.30",
+            "resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.6.30.tgz",
+            "integrity": "sha512-Xhe7D7Zdms8FaVbdT1brYqo8biZiMEF1GIzrelhXYP4skth52RjHrW5X9HyuwIm51rOd0dmXN9IL27UMIazpkg==",
             "license": "MIT",
             "dependencies": {
+                "@opentelemetry/semantic-conventions": "^1.39.0",
                 "@standard-schema/spec": "^1.1.0",
                 "zod": "^4.3.6"
             },
             "peerDependencies": {
-                "@better-auth/utils": "0.3.1",
-                "@better-fetch/fetch": "1.1.21",
+                "@better-auth/utils": "0.4.2",
+                "@better-fetch/fetch": "1.3.1",
                 "@cloudflare/workers-types": ">=4",
-                "better-call": "1.3.2",
+                "@opentelemetry/api": "^1.9.0",
+                "better-call": "1.4.0",
                 "jose": "^6.1.0",
-                "kysely": "^0.28.5",
+                "kysely": "^0.28.5 || ^0.29.0",
                 "nanostores": "^1.0.1"
             },
             "peerDependenciesMeta": {
                 "@cloudflare/workers-types": {
                     "optional": true
+                },
+                "@opentelemetry/api": {
+                    "optional": true
                 }
             }
         },
         "node_modules/@better-auth/drizzle-adapter": {
-            "version": "1.5.5",
-            "resolved": "https://registry.npmjs.org/@better-auth/drizzle-adapter/-/drizzle-adapter-1.5.5.tgz",
-            "integrity": "sha512-HAi9xAP40oDt48QZeYBFTcmg3vt1Jik90GwoRIfangd7VGbxesIIDBJSnvwMbZ52GBIc6+V4FRw9lasNiNrPfw==",
+            "version": "1.6.30",
+            "resolved": "https://registry.npmjs.org/@better-auth/drizzle-adapter/-/drizzle-adapter-1.6.30.tgz",
+            "integrity": "sha512-k8cRfUViD++xzK51MmzvtcTZCurss8Oq4iheak6sqlMbqgRgmaeD85M+HXitOlZAb27uLz6gsMh9fcQwW0E8aA==",
             "license": "MIT",
             "peerDependencies": {
-                "@better-auth/core": "1.5.5",
-                "@better-auth/utils": "^0.3.0",
-                "drizzle-orm": ">=0.41.0"
+                "@better-auth/core": "^1.6.30",
+                "@better-auth/utils": "0.4.2",
+                "drizzle-orm": "^0.45.2"
             },
             "peerDependenciesMeta": {
                 "drizzle-orm": {
@@ -411,45 +416,55 @@
             }
         },
         "node_modules/@better-auth/kysely-adapter": {
-            "version": "1.5.5",
-            "resolved": "https://registry.npmjs.org/@better-auth/kysely-adapter/-/kysely-adapter-1.5.5.tgz",
-            "integrity": "sha512-LmHffIVnqbfsxcxckMOoE8MwibWrbVFch+kwPKJ5OFDFv6lin75ufN7ZZ7twH0IMPLT/FcgzaRjP8jRrXRef9g==",
+            "version": "1.6.30",
+            "resolved": "https://registry.npmjs.org/@better-auth/kysely-adapter/-/kysely-adapter-1.6.30.tgz",
+            "integrity": "sha512-4+1vFYBnUYW4JUnGAbHOmRs4No2/bFWXkC1Rge//S0yeWGVD+Mm4oHSn5esVYry/PaXzmPbk1H1xu6Kb9ZRvaQ==",
             "license": "MIT",
             "peerDependencies": {
-                "@better-auth/core": "1.5.5",
-                "@better-auth/utils": "^0.3.0",
-                "kysely": "^0.27.0 || ^0.28.0"
+                "@better-auth/core": "^1.6.30",
+                "@better-auth/utils": "0.4.2",
+                "kysely": "^0.28.17 || ^0.29.0"
+            },
+            "peerDependenciesMeta": {
+                "kysely": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@better-auth/memory-adapter": {
-            "version": "1.5.5",
-            "resolved": "https://registry.npmjs.org/@better-auth/memory-adapter/-/memory-adapter-1.5.5.tgz",
-            "integrity": "sha512-4X0j1/2L+nsgmObjmy9xEGUFWUv38Qjthp558fwS3DAp6ueWWyCaxaD6VJZ7m5qPNMrsBStO5WGP8CmJTEWm7g==",
+            "version": "1.6.30",
+            "resolved": "https://registry.npmjs.org/@better-auth/memory-adapter/-/memory-adapter-1.6.30.tgz",
+            "integrity": "sha512-lHmx6Geyn6YY2YmnTNm1WqUdMRNb875l35S1dBRh5/iAwcA8NAa+1nDU9C1yS4R7bXPPi6JbvFG4ragcbJhFNw==",
             "license": "MIT",
             "peerDependencies": {
-                "@better-auth/core": "1.5.5",
-                "@better-auth/utils": "^0.3.0"
+                "@better-auth/core": "^1.6.30",
+                "@better-auth/utils": "0.4.2"
             }
         },
         "node_modules/@better-auth/mongo-adapter": {
-            "version": "1.5.5",
-            "resolved": "https://registry.npmjs.org/@better-auth/mongo-adapter/-/mongo-adapter-1.5.5.tgz",
-            "integrity": "sha512-P1J9ljL5X5k740I8Rx1esPWNgWYPdJR5hf2CY7BwDSrQFPUHuzeCg0YhtEEP55niNateTXhBqGAcy0fVOeamZg==",
+            "version": "1.6.30",
+            "resolved": "https://registry.npmjs.org/@better-auth/mongo-adapter/-/mongo-adapter-1.6.30.tgz",
+            "integrity": "sha512-4vhNyz2WkrYd96oqRumEYTBukx2070XH6tq2mhDHZAeIT4WjIScZWlckZfwoEYY0QLn/N0Cn4cb+IDT39R3l3Q==",
             "license": "MIT",
             "peerDependencies": {
-                "@better-auth/core": "1.5.5",
-                "@better-auth/utils": "^0.3.0",
+                "@better-auth/core": "^1.6.30",
+                "@better-auth/utils": "0.4.2",
                 "mongodb": "^6.0.0 || ^7.0.0"
+            },
+            "peerDependenciesMeta": {
+                "mongodb": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@better-auth/prisma-adapter": {
-            "version": "1.5.5",
-            "resolved": "https://registry.npmjs.org/@better-auth/prisma-adapter/-/prisma-adapter-1.5.5.tgz",
-            "integrity": "sha512-CliDd78CXHzzwQIXhCdwGr5Ml53i6JdCHWV7PYwTIJz9EAm6qb2RVBdpP3nqEfNjINGM22A6gfleCgCdZkTIZg==",
+            "version": "1.6.30",
+            "resolved": "https://registry.npmjs.org/@better-auth/prisma-adapter/-/prisma-adapter-1.6.30.tgz",
+            "integrity": "sha512-C4XfyWHbO8oLj5R9ws5ZSrLQir6D995HPOzfgsElvnqr4LoPoqL5H2Aryt9XChvO/JhnyBg3puagMVPRF3Hamw==",
             "license": "MIT",
             "peerDependencies": {
-                "@better-auth/core": "1.5.5",
-                "@better-auth/utils": "^0.3.0",
+                "@better-auth/core": "^1.6.30",
+                "@better-auth/utils": "0.4.2",
                 "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0",
                 "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0"
             },
@@ -463,28 +478,30 @@
             }
         },
         "node_modules/@better-auth/telemetry": {
-            "version": "1.5.5",
-            "resolved": "https://registry.npmjs.org/@better-auth/telemetry/-/telemetry-1.5.5.tgz",
-            "integrity": "sha512-1+lklxArn4IMHuU503RcPdXrSG2tlXt4jnGG3omolmspQ7tktg/Y9XO/yAkYDurtvMn1xJ8X1Ov01Ji/r5s9BQ==",
+            "version": "1.6.30",
+            "resolved": "https://registry.npmjs.org/@better-auth/telemetry/-/telemetry-1.6.30.tgz",
+            "integrity": "sha512-wvY+/rWsHsGHw7agr2VU7jasWtSIA6obsHjJGS4BwiZ82FRbM9Q1ngzDldhn3No0ZOlrJ82BGFtMQnNVMXpxrw==",
             "license": "MIT",
-            "dependencies": {
-                "@better-auth/utils": "0.3.1",
-                "@better-fetch/fetch": "1.1.21"
-            },
             "peerDependencies": {
-                "@better-auth/core": "1.5.5"
+                "@better-auth/core": "^1.6.30",
+                "@better-auth/utils": "0.4.2",
+                "@better-fetch/fetch": "1.3.1"
             }
         },
         "node_modules/@better-auth/utils": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/@better-auth/utils/-/utils-0.3.1.tgz",
-            "integrity": "sha512-+CGp4UmZSUrHHnpHhLPYu6cV+wSUSvVbZbNykxhUDocpVNTo9uFFxw/NqJlh1iC4wQ9HKKWGCKuZ5wUgS0v6Kg==",
-            "license": "MIT"
+            "version": "0.4.2",
+            "resolved": "https://registry.npmjs.org/@better-auth/utils/-/utils-0.4.2.tgz",
+            "integrity": "sha512-AUxrvu+HaaODsUyzDxFgwd/8RZ1yZaYo42LXKSrU2oGgR38pS1ij8nqQKNgtTWoYGpNevNXtCfgTy6loHveW9A==",
+            "license": "MIT",
+            "dependencies": {
+                "@noble/hashes": "^2.0.1"
+            }
         },
         "node_modules/@better-fetch/fetch": {
-            "version": "1.1.21",
-            "resolved": "https://registry.npmjs.org/@better-fetch/fetch/-/fetch-1.1.21.tgz",
-            "integrity": "sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A=="
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/@better-fetch/fetch/-/fetch-1.3.1.tgz",
+            "integrity": "sha512-ABkD1WhyfPZprKRQI3bhATjeiFuNWC9PXhfGWqL+sg/gKrM977oFrYkdb4msM3hgUGonr7KlOsOFT5TU2rht9g==",
+            "license": "MIT"
         },
         "node_modules/@chevrotain/cst-dts-gen": {
             "version": "10.5.0",
@@ -1362,16 +1379,6 @@
                 "@jridgewell/sourcemap-codec": "^1.4.14"
             }
         },
-        "node_modules/@mongodb-js/saslprep": {
-            "version": "1.4.6",
-            "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.4.6.tgz",
-            "integrity": "sha512-y+x3H1xBZd38n10NZF/rEBlvDOOMQ6LKUTHqr8R9VkJ+mmQOYtJFxIlkkK8fZrtOiL6VixbOBWMbZGBdal3Z1g==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "sparse-bitfield": "^3.0.3"
-            }
-        },
         "node_modules/@mrleebo/prisma-ast": {
             "version": "0.13.1",
             "resolved": "https://registry.npmjs.org/@mrleebo/prisma-ast/-/prisma-ast-0.13.1.tgz",
@@ -1416,6 +1423,15 @@
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=8.0.0"
+            }
+        },
+        "node_modules/@opentelemetry/semantic-conventions": {
+            "version": "1.43.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
+            "integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=14"
             }
         },
         "node_modules/@phc/format": {
@@ -3026,23 +3042,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/@types/webidl-conversions": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
-            "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==",
-            "license": "MIT",
-            "peer": true
-        },
-        "node_modules/@types/whatwg-url": {
-            "version": "13.0.0",
-            "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-13.0.0.tgz",
-            "integrity": "sha512-N8WXpbE6Wgri7KUSvrmQcqrMllKZ9uxkYWMt+mCSGwNc0Hsw9VQTW7ApqI4XNrx6/SaM2QQJCzMPDEXE058s+Q==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@types/webidl-conversions": "*"
-            }
-        },
         "node_modules/@typescript-eslint/eslint-plugin": {
             "version": "8.57.1",
             "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.57.1.tgz",
@@ -3543,26 +3542,26 @@
             }
         },
         "node_modules/better-auth": {
-            "version": "1.5.5",
-            "resolved": "https://registry.npmjs.org/better-auth/-/better-auth-1.5.5.tgz",
-            "integrity": "sha512-GpVPaV1eqr3mOovKfghJXXk6QvlcVeFbS3z+n+FPDid5rK/2PchnDtiaVCzWyXA9jH2KkirOfl+JhAUvnja0Eg==",
+            "version": "1.6.30",
+            "resolved": "https://registry.npmjs.org/better-auth/-/better-auth-1.6.30.tgz",
+            "integrity": "sha512-+fmPXSZFE7MDmLcppkmzUGMtQxzZXsJbKi5rUunmIYtSQZIgNCZHNSQFwK/ywx10uczkzbtVkrHm75i4o7+gpQ==",
             "license": "MIT",
             "dependencies": {
-                "@better-auth/core": "1.5.5",
-                "@better-auth/drizzle-adapter": "1.5.5",
-                "@better-auth/kysely-adapter": "1.5.5",
-                "@better-auth/memory-adapter": "1.5.5",
-                "@better-auth/mongo-adapter": "1.5.5",
-                "@better-auth/prisma-adapter": "1.5.5",
-                "@better-auth/telemetry": "1.5.5",
-                "@better-auth/utils": "0.3.1",
-                "@better-fetch/fetch": "1.1.21",
+                "@better-auth/core": "1.6.30",
+                "@better-auth/drizzle-adapter": "1.6.30",
+                "@better-auth/kysely-adapter": "1.6.30",
+                "@better-auth/memory-adapter": "1.6.30",
+                "@better-auth/mongo-adapter": "1.6.30",
+                "@better-auth/prisma-adapter": "1.6.30",
+                "@better-auth/telemetry": "1.6.30",
+                "@better-auth/utils": "0.4.2",
+                "@better-fetch/fetch": "1.3.1",
                 "@noble/ciphers": "^2.1.1",
                 "@noble/hashes": "^2.0.1",
-                "better-call": "1.3.2",
+                "better-call": "1.4.0",
                 "defu": "^6.1.4",
                 "jose": "^6.1.3",
-                "kysely": "^0.28.11",
+                "kysely": "^0.28.17 || ^0.29.0",
                 "nanostores": "^1.1.1",
                 "zod": "^4.3.6"
             },
@@ -3574,7 +3573,7 @@
                 "@tanstack/solid-start": "^1.0.0",
                 "better-sqlite3": "^12.0.0",
                 "drizzle-kit": ">=0.31.4",
-                "drizzle-orm": ">=0.41.0",
+                "drizzle-orm": "^0.45.2",
                 "mongodb": "^6.0.0 || ^7.0.0",
                 "mysql2": "^3.0.0",
                 "next": "^14.0.0 || ^15.0.0 || ^16.0.0",
@@ -3648,15 +3647,15 @@
             }
         },
         "node_modules/better-call": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/better-call/-/better-call-1.3.2.tgz",
-            "integrity": "sha512-4cZIfrerDsNTn3cm+MhLbUePN0gdwkhSXEuG7r/zuQ8c/H7iU0/jSK5TD3FW7U0MgKHce/8jGpPYNO4Ve+4NBw==",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/better-call/-/better-call-1.4.0.tgz",
+            "integrity": "sha512-bBKOT4vv1kZLDgxVePdilk/Jwkn+dtRRsmi3DzHcDP+WnswyVl6dR59l2HEeP/0cB+bDoopASAesWDPIdd/zZA==",
             "license": "MIT",
             "dependencies": {
-                "@better-auth/utils": "^0.3.1",
-                "@better-fetch/fetch": "^1.1.21",
-                "rou3": "^0.7.12",
-                "set-cookie-parser": "^3.0.1"
+                "@better-auth/utils": "^0.5.0",
+                "@better-fetch/fetch": "^1.3.1",
+                "rou3": "^0.9.1",
+                "set-cookie-parser": "^3.1.2"
             },
             "peerDependencies": {
                 "zod": "^4.0.0"
@@ -3665,6 +3664,15 @@
                 "zod": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/better-call/node_modules/@better-auth/utils": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/@better-auth/utils/-/utils-0.5.0.tgz",
+            "integrity": "sha512-BL8W4EfIZFwlu0r54m3v1ztjDhu6dDe/amLTm0xybmbZaNgYUqhD3SjpAsnq0q8YD6/ki4iwIgxJNLP/N3TxiA==",
+            "license": "MIT",
+            "dependencies": {
+                "@noble/hashes": "^2.0.1"
             }
         },
         "node_modules/better-sqlite3": {
@@ -3763,16 +3771,6 @@
             },
             "engines": {
                 "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-            }
-        },
-        "node_modules/bson": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/bson/-/bson-7.2.0.tgz",
-            "integrity": "sha512-YCEo7KjMlbNlyHhz7zAZNDpIpQbd+wOEHJYezv0nMYTn4x31eIUM2yomNNubclAt63dObUzKHWsBLJ9QcZNSnQ==",
-            "license": "Apache-2.0",
-            "peer": true,
-            "engines": {
-                "node": ">=20.19.0"
             }
         },
         "node_modules/buffer": {
@@ -5511,9 +5509,9 @@
             }
         },
         "node_modules/jose": {
-            "version": "6.2.2",
-            "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
-            "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+            "version": "6.2.10",
+            "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.10.tgz",
+            "integrity": "sha512-iiW7J9qRFlGxvCOIBDBDxFePQSn7ZMAnrYGhrrOo6siO/MIqwfyilLR27pkfDgUk+raLuzADS8A3S/KLBisc0g==",
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/panva"
@@ -5607,12 +5605,12 @@
             }
         },
         "node_modules/kysely": {
-            "version": "0.28.17",
-            "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.28.17.tgz",
-            "integrity": "sha512-nbD8lB9EB3wNdMhOCdx5Li8DxnLbvKByylRLcJ1h+4SkrowVeECAyZlyiKMThF7xFdRz0jSQ2MoJr+wXux2y0Q==",
+            "version": "0.29.5",
+            "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.29.5.tgz",
+            "integrity": "sha512-ooa+eSbBNPTo3MycPEuW5jdrxQdQwdtB3LC3h43FiXQbIry5tR0C5lDG7eealK0E4D7XjrnOP5DIUg/LyjRMYQ==",
             "license": "MIT",
             "engines": {
-                "node": ">=20.0.0"
+                "node": ">=22.0.0"
             }
         },
         "node_modules/levn": {
@@ -6276,13 +6274,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/memory-pager": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
-            "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
-            "license": "MIT",
-            "peer": true
-        },
         "node_modules/micromark": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
@@ -6791,67 +6782,6 @@
             "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
             "license": "MIT"
         },
-        "node_modules/mongodb": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-7.1.0.tgz",
-            "integrity": "sha512-kMfnKunbolQYwCIyrkxNJFB4Ypy91pYqua5NargS/f8ODNSJxT03ZU3n1JqL4mCzbSih8tvmMEMLpKTT7x5gCg==",
-            "license": "Apache-2.0",
-            "peer": true,
-            "dependencies": {
-                "@mongodb-js/saslprep": "^1.3.0",
-                "bson": "^7.1.1",
-                "mongodb-connection-string-url": "^7.0.0"
-            },
-            "engines": {
-                "node": ">=20.19.0"
-            },
-            "peerDependencies": {
-                "@aws-sdk/credential-providers": "^3.806.0",
-                "@mongodb-js/zstd": "^7.0.0",
-                "gcp-metadata": "^7.0.1",
-                "kerberos": "^7.0.0",
-                "mongodb-client-encryption": ">=7.0.0 <7.1.0",
-                "snappy": "^7.3.2",
-                "socks": "^2.8.6"
-            },
-            "peerDependenciesMeta": {
-                "@aws-sdk/credential-providers": {
-                    "optional": true
-                },
-                "@mongodb-js/zstd": {
-                    "optional": true
-                },
-                "gcp-metadata": {
-                    "optional": true
-                },
-                "kerberos": {
-                    "optional": true
-                },
-                "mongodb-client-encryption": {
-                    "optional": true
-                },
-                "snappy": {
-                    "optional": true
-                },
-                "socks": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/mongodb-connection-string-url": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-7.0.1.tgz",
-            "integrity": "sha512-h0AZ9A7IDVwwHyMxmdMXKy+9oNlF0zFoahHiX3vQ8e3KFcSP3VmsmfvtRSuLPxmyv2vjIDxqty8smTgie/SNRQ==",
-            "license": "Apache-2.0",
-            "peer": true,
-            "dependencies": {
-                "@types/whatwg-url": "^13.0.0",
-                "whatwg-url": "^14.1.0"
-            },
-            "engines": {
-                "node": ">=20.19.0"
-            }
-        },
         "node_modules/ms": {
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -6909,9 +6839,9 @@
             }
         },
         "node_modules/nanostores": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/nanostores/-/nanostores-1.2.0.tgz",
-            "integrity": "sha512-F0wCzbsH80G7XXo0Jd9/AVQC7ouWY6idUCTnMwW5t/Rv9W8qmO6endavDwg7TNp5GbugwSukFMVZqzPSrSMndg==",
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/nanostores/-/nanostores-1.5.2.tgz",
+            "integrity": "sha512-B0UbxzK1s0CN8Xht6r+7iT5+xV8PTaRERR1nATeplRv1Rw5YLWfVAid0hkqY3EceqpG4RjTk8GAwIxQY39Rnwg==",
             "funding": [
                 {
                     "type": "github",
@@ -7723,6 +7653,7 @@
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
             "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6"
@@ -8139,9 +8070,9 @@
             "license": "MIT"
         },
         "node_modules/rou3": {
-            "version": "0.7.12",
-            "resolved": "https://registry.npmjs.org/rou3/-/rou3-0.7.12.tgz",
-            "integrity": "sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg==",
+            "version": "0.9.2",
+            "resolved": "https://registry.npmjs.org/rou3/-/rou3-0.9.2.tgz",
+            "integrity": "sha512-3SOzvaAg8rkHrXtRjpCvCvbyO5to9oOO27Z/XqHEYXfMRVSw/qMIVdmaOk9W2lcRLtR6dlqTjo9hDeJk70QBYQ==",
             "license": "MIT"
         },
         "node_modules/safe-buffer": {
@@ -8192,9 +8123,9 @@
             "integrity": "sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q=="
         },
         "node_modules/set-cookie-parser": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.0.tgz",
-            "integrity": "sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.2.tgz",
+            "integrity": "sha512-5/r/lTwbJ3zQ+qwdUFZYeRNqda7P5HD8zQKqlSjdGt1/S0cjLAphHusj4Y58ahDtWn/g32xrIS58/ikOvwl0Lw==",
             "license": "MIT"
         },
         "node_modules/shebang-command": {
@@ -8333,16 +8264,6 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
-            }
-        },
-        "node_modules/sparse-bitfield": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
-            "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "memory-pager": "^1.0.2"
             }
         },
         "node_modules/sqlstring": {
@@ -8581,19 +8502,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/SuperchupuDev"
-            }
-        },
-        "node_modules/tr46": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
-            "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "punycode": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=18"
             }
         },
         "node_modules/trim-lines": {
@@ -9037,30 +8945,6 @@
             "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/webidl-conversions": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-            "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
-            "license": "BSD-2-Clause",
-            "peer": true,
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/whatwg-url": {
-            "version": "14.2.0",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
-            "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "tr46": "^5.1.0",
-                "webidl-conversions": "^7.0.0"
-            },
-            "engines": {
-                "node": ">=18"
-            }
         },
         "node_modules/which": {
             "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         "@prisma/client": "^7.4.1",
         "@tailwindcss/vite": "^4.1.18",
         "argon2": "^0.44.0",
-        "better-auth": "^1.4.6",
+        "better-auth": "1.6.30",
         "better-sqlite3": "^12.5.0",
         "croner": "^9.1.0",
         "dlv": "^1.1.3",

--- a/prisma/migrations/20260827180000_upgrade_better_auth_1_6_30/migration.sql
+++ b/prisma/migrations/20260827180000_upgrade_better_auth_1_6_30/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+ALTER TABLE "twoFactor" ADD COLUMN "failedVerificationCount" INTEGER DEFAULT 0;
+ALTER TABLE "twoFactor" ADD COLUMN "lockedUntil" DATETIME;
+ALTER TABLE "twoFactor" ADD COLUMN "verified" BOOLEAN DEFAULT true;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -67,11 +67,14 @@ model User {
 }
 
 model TwoFactor {
-    id          String @id @default(uuid())
-    secret      String
-    backupCodes String
-    userId      String
-    user        User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+    id                      String    @id @default(uuid())
+    secret                  String
+    backupCodes             String
+    userId                  String
+    user                    User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+    verified                Boolean?  @default(true)
+    failedVerificationCount Int?      @default(0)
+    lockedUntil             DateTime?
 
     @@map("twoFactor")
 }


### PR DESCRIPTION
## Summary

- pin Better Auth to 1.6.30 to remove the applicable OAuth account-linking vulnerability
- add the three nullable two-factor fields required by Better Auth 1.6
- migrate existing two-factor rows as verified with zero failed attempts

Supersedes #537.

## Validation

- clean npm install on Node 25
- Prisma schema validation and client generation
- all 35 migrations on a fresh SQLite database
- additive migration against an existing two-factor row, preserving its secret and backup codes
- production build
- Playwright: 15/15
- Hurl API authentication suite: 11/11
- Better Auth critical audit finding removed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced two-factor authentication security by tracking failed verification attempts.
  - Added temporary account lockouts after repeated unsuccessful verification attempts.
  - Improved handling of two-factor setup status to distinguish verified and unverified configurations.

- **Bug Fixes**
  - Improved reliability and consistency of two-factor authentication state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->