### PR TITLE
fix(deps): update Hono packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
             "name": "hemmelig-app",
             "version": "7.0.0",
             "dependencies": {
-                "@hono/node-server": "^1.19.11",
+                "@hono/node-server": "^1.19.17",
                 "@hono/swagger-ui": "^0.5.2",
                 "@hono/zod-validator": "^0.7.5",
                 "@prisma/adapter-better-sqlite3": "^7.4.1",
@@ -20,7 +20,7 @@
                 "croner": "^9.1.0",
                 "dlv": "^1.1.3",
                 "dotenv": "^17.2.3",
-                "hono": "^4.12.8",
+                "hono": "^4.13.5",
                 "hono-rate-limiter": "^0.4.2",
                 "ip-range-check": "^0.2.0",
                 "is-cidr": "^6.0.1",
@@ -1222,9 +1222,9 @@
             "optional": true
         },
         "node_modules/@hono/node-server": {
-            "version": "1.19.11",
-            "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
-            "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+            "version": "1.19.17",
+            "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.17.tgz",
+            "integrity": "sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==",
             "license": "MIT",
             "engines": {
                 "node": ">=18.14.1"
@@ -5121,9 +5121,9 @@
             }
         },
         "node_modules/hono": {
-            "version": "4.12.8",
-            "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.8.tgz",
-            "integrity": "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==",
+            "version": "4.13.5",
+            "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.5.tgz",
+            "integrity": "sha512-O6+/eCYRkzzzy0rPWwKLiGBR1nFuUPZynnwjxN1MBA62NNqbT0wQEzQyK2gSO5yDIDB336sXQleAhOHrzlYyKw==",
             "license": "MIT",
             "engines": {
                 "node": ">=16.9.0"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
         "security"
     ],
     "dependencies": {
-        "@hono/node-server": "^1.19.11",
+        "@hono/node-server": "^1.19.17",
         "@hono/swagger-ui": "^0.5.2",
         "@hono/zod-validator": "^0.7.5",
         "@prisma/adapter-better-sqlite3": "^7.4.1",
@@ -50,7 +50,7 @@
         "croner": "^9.1.0",
         "dlv": "^1.1.3",
         "dotenv": "^17.2.3",
-        "hono": "^4.12.8",
+        "hono": "^4.13.5",
         "hono-rate-limiter": "^0.4.2",
         "ip-range-check": "^0.2.0",
         "is-cidr": "^6.0.1",


### PR DESCRIPTION
## Summary

- update Hono from 4.12.8 to 4.13.5
- update @hono/node-server from 1.19.11 to 1.19.17
- remove the vulnerable direct Hono package versions while staying on the current major releases

This supersedes #555 and the Hono portion of #558. Prisma's nested Hono copies are handled by a separate aligned Prisma update.

## Validation

- `npm ci`
- `npx prisma validate`
- `npx prisma generate`
- `npm run build`
- `npx playwright test` (15 passed)
- `npm test` (Hurl API suite passed)
- `npx prettier --check package.json package-lock.json`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Maintenance**
  * Updated underlying server and web framework components to newer versions.
  * No user-facing feature changes were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->