### PR TITLE
fix(cli): update Go crypto dependency

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.25.x'
 
       - name: Build binary
         working-directory: cli-go

--- a/cli-go/go.mod
+++ b/cli-go/go.mod
@@ -1,5 +1,5 @@
 module github.com/HemmeligOrg/hemmelig-cli
 
-go 1.24.0
+go 1.25.0
 
-require golang.org/x/crypto v0.45.0
+require golang.org/x/crypto v0.52.0

--- a/cli-go/go.sum
+++ b/cli-go/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/crypto v0.45.0 h1:jMBrvKuj23MTlT0bQEOBcAE0mjg8mK9RXFhRH6nyF3Q=
-golang.org/x/crypto v0.45.0/go.mod h1:XTGrrkGJve7CYK7J8PEww4aY7gM3qMCElcJQ8n8JdX4=
+golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
+golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=


### PR DESCRIPTION
## Summary

- update `golang.org/x/crypto` from 0.45.0 to the first patched 0.52.0 release
- raise the CLI module minimum to Go 1.25 as required by that dependency
- update the release workflow from Go 1.21 to the latest Go 1.25 patch release so tagged builds remain reproducible

This replaces #566, which updates the module minimum but leaves the release workflow on an incompatible Go version.

## Validation

- `GOTOOLCHAIN=go1.25.0 go test ./...`
- `GOTOOLCHAIN=go1.25.0 go vet ./...`
- `GOTOOLCHAIN=go1.25.0 go mod verify`
- release-equivalent cross-builds for Linux amd64/arm64, macOS amd64/arm64, and Windows amd64
- Linux binary `--version` and `--help` smoke tests
- `govulncheck ./...`: 0 reachable package or symbol vulnerabilities
- `git diff --check`

`govulncheck` reports only the module-level notice that `x/crypto/openpgp` is unmaintained; this CLI imports only `x/crypto/pbkdf2`.