### PR TITLE
fix(users): clear add-user form after submission

### DIFF
--- a/src/components/AddUserModal.tsx
+++ b/src/components/AddUserModal.tsx
@@ -1,5 +1,5 @@
 import { Key, Mail, Shield, User } from 'lucide-react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Modal } from './Modal';
 import { ModalInput } from './ModalInput';
@@ -25,6 +25,16 @@ export function AddUserModal({ isOpen, onClose, onSave }: AddUserModalProps) {
     const [email, setEmail] = useState('');
     const [password, setPassword] = useState('');
     const [role, setRole] = useState('user');
+
+    useEffect(() => {
+        if (!isOpen) {
+            setName('');
+            setUsername('');
+            setEmail('');
+            setPassword('');
+            setRole('user');
+        }
+    }, [isOpen]);
 
     const handleSave = () => {
         onSave({

--- a/src/components/AddUserModal.tsx
+++ b/src/components/AddUserModal.tsx
@@ -1,5 +1,5 @@
 import { Key, Mail, Shield, User } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Modal } from './Modal';
 import { ModalInput } from './ModalInput';
@@ -25,8 +25,10 @@ export function AddUserModal({ isOpen, onClose, onSave }: AddUserModalProps) {
     const [email, setEmail] = useState('');
     const [password, setPassword] = useState('');
     const [role, setRole] = useState('user');
+    const [previousIsOpen, setPreviousIsOpen] = useState(isOpen);
 
-    useEffect(() => {
+    if (isOpen !== previousIsOpen) {
+        setPreviousIsOpen(isOpen);
         if (!isOpen) {
             setName('');
             setUsername('');
@@ -34,7 +36,7 @@ export function AddUserModal({ isOpen, onClose, onSave }: AddUserModalProps) {
             setPassword('');
             setRole('user');
         }
-    }, [isOpen]);
+    }
 
     const handleSave = () => {
         onSave({

--- a/src/components/ModalInput.tsx
+++ b/src/components/ModalInput.tsx
@@ -45,6 +45,7 @@ export function ModalInput({
                 <Icon className={iconClass} />
                 {as === 'select' ? (
                     <select
+                        aria-label={label}
                         value={value}
                         onChange={(e) => onChange(e.target.value)}
                         className={`${inputClass} appearance-none`}
@@ -57,6 +58,7 @@ export function ModalInput({
                     </select>
                 ) : (
                     <input
+                        aria-label={label}
                         type={type ?? 'text'}
                         value={value}
                         onChange={(e) => onChange(e.target.value)}

--- a/tests/e2e/fixtures.ts
+++ b/tests/e2e/fixtures.ts
@@ -1,35 +1,26 @@
 import { test as base, expect, Page } from '@playwright/test';
 import { TEST_USER } from './global-setup';
 
-async function loginUser(page: Page, email: string, password: string): Promise<boolean> {
+async function loginUser(page: Page, username: string, password: string): Promise<void> {
     await page.goto('/login');
 
     // Fill login form
-    await page.getByPlaceholder(/username/i).fill(email);
+    await page.getByPlaceholder(/username/i).fill(username);
     await page.getByPlaceholder(/password/i).fill(password);
     await page.getByRole('button', { name: /sign in/i }).click();
 
-    // Wait for navigation - could be home, dashboard, or 2FA
-    try {
-        await page.waitForURL(/^\/$|\/dashboard|\/verify-2fa/, { timeout: 10000 });
-        return true;
-    } catch {
-        return false;
-    }
+    await page.waitForURL(
+        (url) => url.pathname.startsWith('/dashboard') || url.pathname === '/verify-2fa',
+        { timeout: 10000 }
+    );
 }
 
 // Extend the base test with auth fixture
 export const test = base.extend<{ authenticatedPage: Page }>({
-    authenticatedPage: async ({ page }, use) => {
-        // Check if authentication is required
-        await page.goto('/');
+    authenticatedPage: async ({ page }, provideAuthenticatedPage) => {
+        await loginUser(page, TEST_USER.username, TEST_USER.password);
 
-        if (page.url().includes('/login')) {
-            // Login with test user (created in global setup)
-            await loginUser(page, TEST_USER.email, TEST_USER.password);
-        }
-
-        await use(page);
+        await provideAuthenticatedPage(page);
     },
 });
 

--- a/tests/e2e/fixtures.ts
+++ b/tests/e2e/fixtures.ts
@@ -9,10 +9,7 @@ async function loginUser(page: Page, username: string, password: string): Promis
     await page.getByPlaceholder(/password/i).fill(password);
     await page.getByRole('button', { name: /sign in/i }).click();
 
-    await page.waitForURL(
-        (url) => url.pathname.startsWith('/dashboard') || url.pathname === '/verify-2fa',
-        { timeout: 10000 }
-    );
+    await page.waitForURL((url) => url.pathname.startsWith('/dashboard'), { timeout: 10000 });
 }
 
 // Extend the base test with auth fixture

--- a/tests/e2e/users.spec.ts
+++ b/tests/e2e/users.spec.ts
@@ -19,6 +19,9 @@ test.describe('User management', () => {
         await page.getByRole('button', { name: 'Add User' }).last().click();
 
         await expect(page.getByRole('heading', { name: 'Add User' })).toBeHidden();
+        await expect(page.getByRole('row').filter({ hasText: 'seconduser' })).toContainText(
+            'second@example.com'
+        );
         await page.getByRole('button', { name: 'Add User' }).click();
 
         await expect(nameInput).toHaveValue('');

--- a/tests/e2e/users.spec.ts
+++ b/tests/e2e/users.spec.ts
@@ -5,22 +5,26 @@ test.describe('User management', () => {
         await page.goto('/dashboard/users');
         await page.getByRole('button', { name: 'Add User' }).click();
 
-        const modal = page.getByRole('heading', { name: 'Add User' }).locator('../..');
-        const inputs = modal.locator('input');
-        await inputs.nth(0).fill('Second User');
-        await inputs.nth(1).fill('seconduser');
-        await inputs.nth(2).fill('second@example.com');
-        await inputs.nth(3).fill('SecondPassword123!');
-        await modal.locator('select').selectOption('admin');
-        await modal.getByRole('button', { name: 'Add User' }).click();
+        const nameInput = page.getByLabel('Name', { exact: true });
+        const usernameInput = page.getByLabel('Username', { exact: true });
+        const emailInput = page.getByLabel('Email', { exact: true });
+        const passwordInput = page.getByLabel('Password', { exact: true });
+        const roleSelect = page.getByLabel('Role', { exact: true });
 
-        await expect(modal).toBeHidden();
+        await nameInput.fill('Second User');
+        await usernameInput.fill('seconduser');
+        await emailInput.fill('second@example.com');
+        await passwordInput.fill('SecondPassword123!');
+        await roleSelect.selectOption('admin');
+        await page.getByRole('button', { name: 'Add User' }).last().click();
+
+        await expect(page.getByRole('heading', { name: 'Add User' })).toBeHidden();
         await page.getByRole('button', { name: 'Add User' }).click();
 
-        await expect(inputs.nth(0)).toHaveValue('');
-        await expect(inputs.nth(1)).toHaveValue('');
-        await expect(inputs.nth(2)).toHaveValue('');
-        await expect(inputs.nth(3)).toHaveValue('');
-        await expect(modal.locator('select')).toHaveValue('user');
+        await expect(nameInput).toHaveValue('');
+        await expect(usernameInput).toHaveValue('');
+        await expect(emailInput).toHaveValue('');
+        await expect(passwordInput).toHaveValue('');
+        await expect(roleSelect).toHaveValue('user');
     });
 });

--- a/tests/e2e/users.spec.ts
+++ b/tests/e2e/users.spec.ts
@@ -1,0 +1,26 @@
+import { expect, test } from './fixtures';
+
+test.describe('User management', () => {
+    test('clears the add user form after creating a user', async ({ authenticatedPage: page }) => {
+        await page.goto('/dashboard/users');
+        await page.getByRole('button', { name: 'Add User' }).click();
+
+        const modal = page.getByRole('heading', { name: 'Add User' }).locator('../..');
+        const inputs = modal.locator('input');
+        await inputs.nth(0).fill('Second User');
+        await inputs.nth(1).fill('seconduser');
+        await inputs.nth(2).fill('second@example.com');
+        await inputs.nth(3).fill('SecondPassword123!');
+        await modal.locator('select').selectOption('admin');
+        await modal.getByRole('button', { name: 'Add User' }).click();
+
+        await expect(modal).toBeHidden();
+        await page.getByRole('button', { name: 'Add User' }).click();
+
+        await expect(inputs.nth(0)).toHaveValue('');
+        await expect(inputs.nth(1)).toHaveValue('');
+        await expect(inputs.nth(2)).toHaveValue('');
+        await expect(inputs.nth(3)).toHaveValue('');
+        await expect(modal.locator('select')).toHaveValue('user');
+    });
+});


### PR DESCRIPTION
## Summary

- incorporate the add-user reset from #548 by @arturict
- clear all sensitive form fields and restore the default `user` role whenever the modal closes
- expose stable accessible names for modal inputs
- repair the authenticated Playwright fixture so it signs in with the username and fails on unsuccessful login
- verify that the user is actually created before checking the reopened form

Closes #504.
Closes #548 after merge.

## Validation

- reproduced the original regression test failure while the fixture remained on the login page
- focused add-user Playwright test (1 passed)
- full `npx playwright test` (17 passed)
- `npm run build`
- ESLint on all changed TypeScript/TSX files
- Prettier on all changed files
- `git diff --check`

## Known baseline

The production build retains the existing chunk-size warning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved accessibility by adding descriptive labels to modal input and select fields.
  - Add User forms now clear entered values and restore the default role whenever dismissed.

- **Tests**
  - Added end-to-end coverage for creating users and confirming the form resets correctly.
  - Improved authentication test setup and navigation checks for dashboard and two-factor authentication flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->