### PR TITLE
feat(i18n): add Czech translation

### DIFF
--- a/src/components/LanguagePicker.tsx
+++ b/src/components/LanguagePicker.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from 'react-i18next';
 
 const LANGUAGES = [
+    { code: 'cs', label: 'CS' },
     { code: 'en', label: 'EN' },
     { code: 'da', label: 'DA' },
     { code: 'de', label: 'DE' },

--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -2,6 +2,7 @@ import i18n from 'i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
 import { initReactI18next } from 'react-i18next';
 
+import csTranslations from './locales/cs/cs.json';
 import daTranslations from './locales/da/da.json';
 import deTranslations from './locales/de/de.json';
 import enTranslations from './locales/en/en.json';
@@ -28,6 +29,7 @@ i18n.use(LanguageDetector)
             escapeValue: false, // not needed for react as it escapes by default
         },
         resources: {
+            cs: { translations: csTranslations },
             en: { translations: enTranslations },
             es: { translations: esTranslations },
             de: { translations: deTranslations },

--- a/src/i18n/locales/cs/cs.json
+++ b/src/i18n/locales/cs/cs.json
@@ -66,7 +66,7 @@
         "character_count": "znaků"
     },
     "create_button": {
-        "creating_secret": "Vytváření tajemství...",
+        "creating_secret": "Vytváření secretu...",
         "create": "Vytvořit"
     },
     "file_upload": {
@@ -90,14 +90,14 @@
         "home": "Domů",
         "sign_in": "Přihlásit se",
         "sign_up": "Registrovat se",
-        "dashboard": "Přehled",
-        "hero_text_part1": "Sdílejte tajemství bezpečně pomocí šifrovaných zpráv, které se po přečtení",
+        "dashboard": "Dashboard",
+        "hero_text_part1": "Sdílejte secrety bezpečně pomocí šifrovaných zpráv, které se po přečtení",
         "hero_text_part2": " automaticky zničí",
         "hero_text_part3": "."
     },
     "dashboard_layout": {
-        "secrets": "Tajemství",
-        "secret_requests": "Žádosti o tajemství",
+        "secrets": "Secrets",
+        "secret_requests": "Žádosti o secrety",
         "account": "Účet",
         "analytics": "Analytika",
         "users": "Uživatelé",
@@ -107,46 +107,46 @@
         "hemmelig": "Hemmelig"
     },
     "secret_settings": {
-        "secret_created_title": "Tajemství bylo vytvořeno!",
-        "secret_created_description": "Vaše tajemství je nyní dostupné na následující URL. Dešifrovací klíč bezpečně uschovejte, protože jej nelze obnovit.",
-        "secret_url_label": "URL tajemství",
+        "secret_created_title": "Secret byl vytvořen!",
+        "secret_created_description": "Váš secret je nyní dostupný na následující URL. Dešifrovací klíč bezpečně uschovejte, protože jej nelze obnovit.",
+        "secret_url_label": "URL secretu",
         "decryption_key_label": "Dešifrovací klíč",
         "password_label": "Heslo",
-        "create_new_secret_button": "Vytvořit nové tajemství",
+        "create_new_secret_button": "Vytvořit nový secret",
         "copy_url_button": "Kopírovat URL",
-        "burn_secret_button": "Zničit tajemství",
-        "max_secrets_per_user_info": "Můžete vytvořit až {{count}} tajemství.",
-        "failed_to_burn": "Tajemství se nepodařilo zničit. Zkuste to znovu."
+        "burn_secret_button": "Zničit secret",
+        "max_secrets_per_user_info": "Můžete vytvořit až {{count}} secretů.",
+        "failed_to_burn": "Secret se nepodařilo zničit. Zkuste to znovu."
     },
     "security_settings": {
         "security_title": "Zabezpečení",
-        "security_description": "Nastavte zabezpečení svého tajemství",
+        "security_description": "Nastavte zabezpečení svého secretu",
         "remember_settings": "Zapamatovat",
         "private_title": "Soukromé",
-        "private_description": "Soukromá tajemství jsou šifrovaná a lze je zobrazit pouze s dešifrovacím klíčem nebo heslem.",
+        "private_description": "Soukromé secrety jsou šifrované a lze je zobrazit pouze s dešifrovacím klíčem nebo heslem.",
         "expiration_title": "Platnost",
-        "expiration_burn_after_time_description": "Nastavte, kdy se má tajemství zničit",
-        "expiration_default_description": "Nastavte, jak dlouho má být tajemství dostupné",
+        "expiration_burn_after_time_description": "Nastavte, kdy se má secret zničit",
+        "expiration_default_description": "Nastavte, jak dlouho má být secret dostupný",
         "max_views_title": "Maximum zobrazení",
         "burn_after_time_mode_title": "Zničení po uplynutí času",
-        "burn_after_time_mode_description": "Tajemství se po uplynutí času zničí bez ohledu na počet zobrazení.",
+        "burn_after_time_mode_description": "Secret se po uplynutí času zničí bez ohledu na počet zobrazení.",
         "password_protection_title": "Ochrana heslem",
         "password_protection_description": "Přidejte další vrstvu zabezpečení pomocí hesla",
         "enter_password_label": "Zadejte heslo",
         "password_placeholder": "Zadejte bezpečné heslo...",
-        "password_hint": "Minimálně 5 znaků. Příjemci budou toto heslo potřebovat k zobrazení tajemství",
+        "password_hint": "Minimálně 5 znaků. Příjemci budou toto heslo potřebovat k zobrazení secretu",
         "password_error": "Heslo musí mít alespoň 5 znaků",
         "ip_restriction_title": "Omezit podle IP nebo CIDR",
-        "ip_restriction_description": "Pomocí CIDR můžete určit rozsahy IP adres, které smějí k tajemství přistupovat.",
+        "ip_restriction_description": "Pomocí CIDR můžete určit rozsahy IP adres, které smějí k secretu přistupovat.",
         "ip_address_cidr_label": "IP adresa nebo rozsah CIDR",
         "ip_address_cidr_placeholder": "192.168.1.0/24 nebo 203.0.113.5",
-        "ip_address_cidr_hint": "K tajemství budou mít přístup pouze požadavky z těchto IP adres",
+        "ip_address_cidr_hint": "K secretu budou mít přístup pouze požadavky z těchto IP adres",
         "burn_after_time_title": "Zničit po uplynutí času",
-        "burn_after_time_description": "Zničit tajemství až po uplynutí času"
+        "burn_after_time_description": "Zničit secret až po uplynutí času"
     },
     "title_field": {
         "placeholder": "Název",
-        "hint": "Dejte tajemství zapamatovatelný název (volitelné)"
+        "hint": "Dejte secretu zapamatovatelný název (volitelné)"
     },
     "views_slider": {
         "min_views": "1",
@@ -222,10 +222,10 @@
             "title": "Nebezpečná zóna",
             "description": "Nevratné a destruktivní akce",
             "delete_account_title": "Smazat účet",
-            "delete_account_description": "Smazání účtu je nevratné. Trvale odstraní váš účet, všechna vaše tajemství a související data.",
-            "delete_account_bullet1": "Všechna vaše tajemství budou trvale smazána",
+            "delete_account_description": "Smazání účtu je nevratné. Trvale odstraní váš účet, všechny vaše secrety a související data.",
+            "delete_account_bullet1": "Všechny vaše secrety budou trvale smazány",
             "delete_account_bullet2": "Data vašeho účtu budou odstraněna z našich serverů",
-            "delete_account_bullet3": "Jakékoli sdílené tajné odkazy budou neplatné",
+            "delete_account_bullet3": "Všechny sdílené odkazy na secrety budou neplatné",
             "delete_account_bullet4": "Tuto akci nelze vrátit zpět",
             "delete_account_confirm": "Jste si jisti, že chcete smazat svůj účet? Tuto akci nelze zrušit.",
             "delete_account_button": "Smazat účet",
@@ -259,24 +259,24 @@
     },
     "analytics_page": {
         "title": "Analytika",
-        "description": "Sledujte aktivitu a přehledy sdílených tajemství",
+        "description": "Sledujte aktivitu a přehledy sdílených secretů",
         "time_range": {
             "last_7_days": "Posledních 7 dní",
             "last_14_days": "Posledních 14 dní",
             "last_30_days": "Posledních 30 dní"
         },
-        "total_secrets": "Celkem tajemství",
+        "total_secrets": "Celkem secretů",
         "from_last_period": "+{{percentage}} % oproti minulému období",
         "total_views": "Celkem zobrazení",
-        "avg_views_per_secret": "Průměr zobrazení na tajemství",
-        "active_secrets": "Aktivní tajemství",
+        "avg_views_per_secret": "Průměr zobrazení na secret",
+        "active_secrets": "Aktivní secrety",
         "daily_activity": {
             "title": "Denní aktivita",
-            "description": "Vytvořená tajemství a zobrazení v čase",
-            "secrets": "Tajemství",
+            "description": "Vytvořené secrety a zobrazení v čase",
+            "secrets": "Secrets",
             "views": "Zobrazení",
-            "secrets_created": "Vytvořená tajemství",
-            "secret_views": "Zobrazení tajemství",
+            "secrets_created": "Vytvořené secrety",
+            "secret_views": "Zobrazení secretů",
             "date": "Datum",
             "trend": "Změna",
             "vs_previous": "oproti předchozímu dni",
@@ -285,11 +285,11 @@
         "locale": "cs-CZ",
         "top_countries": {
             "title": "Nejčastější země",
-            "description": "Odkud jsou vaše tajemství zobrazována",
+            "description": "Odkud jsou vaše secrety zobrazovány",
             "views": "Zobrazení"
         },
         "secret_types": {
-            "title": "Typy tajemství",
+            "title": "Typy secretů",
             "description": "Distribuce podle úrovně ochrany",
             "password_protected": "Chráněno heslem",
             "ip_restricted": "Omezeno IP",
@@ -297,7 +297,7 @@
         },
         "expiration_stats": {
             "title": "Statistiky platnosti",
-            "description": "Jak dlouho tajemství obvykle vydrží",
+            "description": "Jak dlouho secrety obvykle vydrží",
             "one_hour": "1 hodina",
             "one_day": "1 den",
             "one_week_plus": "1 týden a více"
@@ -313,7 +313,7 @@
             "no_data": "Zatím nejsou k dispozici žádné údaje o návštěvách."
         },
         "secret_requests": {
-            "total": "Žádosti o tajemství",
+            "total": "Žádosti o secrety",
             "fulfilled": "Vyřízené žádosti"
         },
         "loading": "Načítám analytiku...",
@@ -353,9 +353,9 @@
             "logo_alt": "Logo instance",
             "logo_invalid_type": "Neplatný typ souboru. Nahrajte prosím PNG, JPEG, GIF, SVG nebo WebP obrázek.",
             "logo_too_large": "Soubor je příliš velký. Maximální velikost je 512KB.",
-            "default_expiration_label": "Výchozí platnost tajemství",
-            "max_secrets_per_user_label": "Maximum tajemství na uživatele",
-            "max_secret_size_label": "Maximální velikost tajemství (MB)",
+            "default_expiration_label": "Výchozí platnost secretu",
+            "max_secrets_per_user_label": "Maximum secretů na uživatele",
+            "max_secret_size_label": "Maximální velikost secretu (MB)",
             "instance_description_label": "Popis instance",
             "important_message_label": "Důležitá zpráva",
             "important_message_placeholder": "Zadejte důležitou zprávu pro zobrazení pro všechny uživatele...",
@@ -375,7 +375,7 @@
             "max_password_attempts_label": "Maximální počet pokusů o zadání hesla",
             "session_timeout_label": "Platnost relace (hodiny)",
             "allow_file_uploads_title": "Povolit nahrávání souborů",
-            "allow_file_uploads_description": "Umožnit uživatelům připojit soubory k tajemstvím"
+            "allow_file_uploads_description": "Umožnit uživatelům připojit soubory k secretům"
         },
         "email_settings": {
             "title": "Nastavení e-mailu",
@@ -389,7 +389,7 @@
             "title": "Databázové informace",
             "description": "Stav databáze a statistiky",
             "stats_title": "Databázové údaje",
-            "total_secrets": "Tajemství celkem:",
+            "total_secrets": "Secrety celkem:",
             "total_users": "Uživatelé celkem:",
             "disk_usage": "Použití disků:",
             "connection_status_title": "Stav připojení",
@@ -417,40 +417,40 @@
         }
     },
     "secrets_page": {
-        "title": "Vaše tajemství",
-        "description": "Spravujte a sledujte svá sdílená tajemství",
-        "create_secret_button": "Vytvořit tajemství",
-        "search_placeholder": "Vyhledávání tajemství...",
+        "title": "Vaše secrety",
+        "description": "Spravujte a sledujte své sdílené secrety",
+        "create_secret_button": "Vytvořit secret",
+        "search_placeholder": "Hledat secrety...",
         "filter": {
-            "all_secrets": "Všechna tajemství",
+            "all_secrets": "Všechny secrety",
             "active": "Aktivní",
             "expired": "Po platnosti"
         },
-        "total_secrets": "Celkem tajemství",
+        "total_secrets": "Celkem secretů",
         "active_secrets": "Aktivní",
         "expired_secrets": "Po platnosti",
-        "no_secrets_found_title": "Nebyla nalezena žádná tajemství",
+        "no_secrets_found_title": "Nebyly nalezeny žádné secrety",
         "no_secrets_found_description_filter": "Zkuste upravit kritéria vyhledávání nebo filtru.",
-        "no_secrets_found_description_empty": "Začněte vytvořením prvního tajemství.",
+        "no_secrets_found_description_empty": "Začněte vytvořením prvního secretu.",
         "password_protected": "Heslo",
         "files": "soubory",
         "table": {
-            "secret_header": "Tajemství",
+            "secret_header": "Secret",
             "created_header": "Vytvořeno",
             "status_header": "Stav",
             "views_header": "Zobrazení",
             "actions_header": "Akce",
-            "untitled_secret": "Nepojmenované tajemství",
+            "untitled_secret": "Secret bez názvu",
             "expired_status": "Po platnosti",
             "active_status": "Aktivní",
             "never_expires": "Bez omezení platnosti",
             "expired_time": "Po platnosti",
             "views_left": "zbývajících zobrazení",
             "copy_url_tooltip": "Kopírovat URL",
-            "open_secret_tooltip": "Otevřít tajemství",
-            "delete_secret_tooltip": "Smazat tajemství",
+            "open_secret_tooltip": "Otevřít secret",
+            "delete_secret_tooltip": "Smazat secret",
             "delete_confirmation_title": "Jste si jistí?",
-            "delete_confirmation_text": "Tuto akci nelze vrátit zpět. Tajemství bude trvale smazáno.",
+            "delete_confirmation_text": "Tuto akci nelze vrátit zpět. Secret bude trvale smazán.",
             "delete_confirm_button": "Ano, smazat",
             "delete_cancel_button": "Zrušit"
         }
@@ -552,10 +552,10 @@
     },
     "register_page": {
         "back_to_hemmelig": "Zpět do Hemmelig",
-        "join_hemmelig": "Připojte se k Hemmelig a sdílejte tajemství bezpečně",
+        "join_hemmelig": "Připojte se k Hemmelig a sdílejte secrety bezpečně",
         "email_password_disabled_message": "Registrace e-mailem a heslem je vypnutá. Použijte jednu z možností přihlášení níže.",
         "create_account_title": "Vytvořit účet",
-        "create_account_description": "Připojte se k Hemmelig a sdílejte tajemství bezpečně",
+        "create_account_description": "Připojte se k Hemmelig a sdílejte secrety bezpečně",
         "username_label": "Uživatelské jméno",
         "username_placeholder": "Zvolte uživatelské jméno",
         "email_label": "E-mail",
@@ -591,34 +591,34 @@
         "account_already_exists": "Účet s tímto e-mailem již existuje. Přihlaste se."
     },
     "secret_form": {
-        "failed_to_create_secret": "Nepodařilo se vytvořit tajemství: {{errorMessage}}",
+        "failed_to_create_secret": "Nepodařilo se vytvořit secret: {{errorMessage}}",
         "failed_to_upload_file": "Nepodařilo se nahrát soubor: {{fileName}}"
     },
     "secret_page": {
         "password_label": "Heslo",
-        "password_placeholder": "Zadejte heslo pro zobrazení tajemství",
+        "password_placeholder": "Zadejte heslo pro zobrazení secretu",
         "decryption_key_label": "Dešifrovací klíč",
         "decryption_key_placeholder": "Zadejte dešifrovací klíč",
-        "view_secret_button": "Zobrazit tajemství",
+        "view_secret_button": "Zobrazit secret",
         "views_remaining_tooltip": "Zbývající zobrazení: {{count}}",
-        "loading_message": "Dešifrování tajemství...",
+        "loading_message": "Dešifrování secretu...",
         "files_title": "Přiložené soubory",
-        "secret_waiting_title": "Někdo s vámi sdílí tajemství",
-        "secret_waiting_description": "Tajemství je zašifrované a zobrazí se až po kliknutí na tlačítko níže.",
-        "one_view_remaining": "Tajemství lze zobrazit už jen jednou",
-        "views_remaining": "Tajemství lze zobrazit ještě {{count}}krát",
+        "secret_waiting_title": "Někdo s vámi sdílí secret",
+        "secret_waiting_description": "Secret je zašifrovaný a zobrazí se až po kliknutí na tlačítko níže.",
+        "one_view_remaining": "Secret lze zobrazit už jen jednou",
+        "views_remaining": "Secret lze zobrazit ještě {{count}}krát",
         "view_warning": "Po zobrazení nelze tuto akci vrátit zpět",
-        "secret_revealed": "Tajemství",
+        "secret_revealed": "Secret",
         "copy_secret": "Kopírovat do schránky",
         "download": "Stáhnout",
-        "create_your_own": "Vytvořit vlastní tajemství",
-        "encrypted_secret": "Zašifrované tajemství",
-        "unlock_secret": "Odemknout tajemství",
-        "delete_secret": "Smazat tajemství",
-        "delete_modal_title": "Smazat tajemství",
-        "delete_modal_message": "Opravdu chcete toto tajemství smazat? Tuto akci nelze vrátit zpět.",
-        "decryption_failed": "Tajemství se nepodařilo dešifrovat. Zkontrolujte heslo nebo dešifrovací klíč.",
-        "fetch_error": "Při načítání tajemství došlo k chybě. Zkuste to znovu."
+        "create_your_own": "Vytvořit vlastní secret",
+        "encrypted_secret": "Zašifrovaný secret",
+        "unlock_secret": "Odemknout secret",
+        "delete_secret": "Smazat secret",
+        "delete_modal_title": "Smazat secret",
+        "delete_modal_message": "Opravdu chcete tento secret smazat? Tuto akci nelze vrátit zpět.",
+        "decryption_failed": "Secret se nepodařilo dešifrovat. Zkontrolujte heslo nebo dešifrovací klíč.",
+        "fetch_error": "Při načítání secretu došlo k chybě. Zkuste to znovu."
     },
     "expiration": {
         "28_days": "28 dní",
@@ -636,8 +636,8 @@
         "clear_errors_button_title": "Smazat chyby"
     },
     "secret_not_found_page": {
-        "title": "Tajemství nebylo nalezeno",
-        "message": "Hledané tajemství neexistuje, vypršela jeho platnost nebo bylo zničeno.",
+        "title": "Secret nebyl nalezen",
+        "message": "Hledaný secret neexistuje, vypršela jeho platnost nebo byl zničen.",
         "error_details": "Podrobnosti chyby:",
         "go_home_button": "Přejít na domovskou stránku"
     },
@@ -650,7 +650,7 @@
             "invite_only_title": "Registrace pouze s pozvánkou",
             "invite_only_description": "Uživatelé se mohou registrovat pouze s platným kódem pozvánky",
             "require_registered_user_title": "Pouze registrovaní uživatelé",
-            "require_registered_user_description": "Pouze registrovaní uživatelé mohou vytvářet tajemství",
+            "require_registered_user_description": "Pouze registrovaní uživatelé mohou vytvářet secrety",
             "disable_email_password_signup_title": "Vypnout registraci e-mailem a heslem",
             "disable_email_password_signup_description": "Vypnout registraci e-mailem a heslem (pouze externí přihlášení)",
             "allowed_domains_title": "Povolené e-mailové domény",
@@ -761,32 +761,32 @@
     },
     "webhook_settings": {
         "title": "Oznámení webhookem",
-        "description": "Informujte externí služby při zobrazení nebo zničení tajemství",
+        "description": "Informujte externí služby při zobrazení nebo zničení secretu",
         "enable_webhooks_title": "Zapnout webhooky",
         "enable_webhooks_description": "Při událostech posílat HTTP POST požadavky na URL webhooku",
         "webhook_url_label": "URL webhooku",
         "webhook_url_placeholder": "https://example.com/webhook",
         "webhook_url_hint": "URL, na kterou se budou posílat data webhooku",
-        "webhook_secret_label": "Tajemství webhooku",
-        "webhook_secret_placeholder": "Zadejte tajemství pro podpis HMAC",
+        "webhook_secret_label": "Webhook secret",
+        "webhook_secret_placeholder": "Zadejte secret pro podpis HMAC",
         "webhook_secret_hint": "Používá se k podepisování dat webhooku pomocí HMAC-SHA256. Podpis se posílá v hlavičce X-Hemmelig-Signature.",
         "events_title": "Události webhooku",
-        "on_view_title": "Tajemství zobrazeno",
-        "on_view_description": "Odeslat webhook při zobrazení tajemství",
-        "on_burn_title": "Tajemství zničeno",
-        "on_burn_description": "Odeslat webhook při zničení nebo smazání tajemství"
+        "on_view_title": "Secret zobrazen",
+        "on_view_description": "Odeslat webhook při zobrazení secretu",
+        "on_burn_title": "Secret zničen",
+        "on_burn_description": "Odeslat webhook při zničení nebo smazání secretu"
     },
     "metrics_settings": {
         "title": "Metriky Prometheus",
         "description": "Zpřístupněte metriky pro monitoring pomocí Promethea",
         "enable_metrics_title": "Zapnout metriky Prometheus",
         "enable_metrics_description": "Zpřístupnit endpoint /api/metrics pro načítání Prometheem",
-        "metrics_secret_label": "Tajemství metrik",
-        "metrics_secret_placeholder": "Zadejte tajemství pro ověření",
+        "metrics_secret_label": "Metrics secret",
+        "metrics_secret_placeholder": "Zadejte secret pro ověření",
         "metrics_secret_hint": "Používá se jako Bearer token pro ověření požadavků na endpoint metrik. Prázdná hodnota vypne ověření (nedoporučuje se).",
         "endpoint_info_title": "Informace o endpointu",
         "endpoint_info_description": "Po zapnutí budou metriky dostupné na:",
-        "endpoint_auth_hint": "Při načítání metrik vložte tajemství jako Bearer token do hlavičky Authorization."
+        "endpoint_auth_hint": "Při načítání metrik vložte secret jako Bearer token do hlavičky Authorization."
     },
     "verify_2fa_page": {
         "back_to_login": "Zpět k přihlášení",
@@ -814,32 +814,32 @@
     },
     "not_found_page": {
         "title": "Stránka nenalezena",
-        "message": "Tahle stránka se vypařila, stejně jako naše tajemství.",
+        "message": "Tahle stránka se vypařila, stejně jako naše secrety.",
         "hint": "Stránka, kterou hledáte, neexistuje nebo byla přesunuta.",
         "go_home_button": "Přejít domů",
-        "create_secret_button": "Vytvořit tajemství"
+        "create_secret_button": "Vytvořit secret"
     },
     "error_boundary": {
         "title": "Něco se pokazilo.",
         "message": "Při zpracovávání vaší žádosti došlo k neočekávané chybě.",
-        "hint": "Vaše tajemství jsou stále v bezpečí. Zkuste stránku obnovit.",
+        "hint": "Vaše secrety jsou stále v bezpečí. Zkuste stránku obnovit.",
         "error_details": "Údaje o chybě:",
         "unknown_error": "Nastala neznámá chyba.",
         "try_again_button": "Zkusit znovu",
         "go_home_button": "Přejít domů"
     },
     "secret_requests_page": {
-        "title": "Žádosti o tajemství",
-        "description": "Vyžádejte si tajemství od ostatních pomocí bezpečných odkazů",
+        "title": "Žádosti o secrety",
+        "description": "Vyžádejte si secrety od ostatních pomocí bezpečných odkazů",
         "create_request_button": "Vytvořit žádost",
-        "no_requests": "Zatím nemáte žádné žádosti o tajemství. Začněte vytvořením první.",
+        "no_requests": "Zatím nemáte žádné žádosti o secrety. Začněte vytvořením první.",
         "table": {
             "title_header": "Název",
             "status_header": "Stav",
-            "secret_expiry_header": "Platnost tajemství",
+            "secret_expiry_header": "Platnost secretu",
             "link_expires_header": "Platnost odkazu",
             "copy_link_tooltip": "Kopírovat odkaz pro odesílatele",
-            "view_secret_tooltip": "Zobrazit tajemství",
+            "view_secret_tooltip": "Zobrazit secret",
             "cancel_tooltip": "Zrušit žádost"
         },
         "status": {
@@ -850,18 +850,21 @@
         },
         "time": {
             "days_one": "{{count}} den",
+            "days_few": "{{count}} dny",
             "days_other": "{{count}} dní",
             "hours_one": "{{count}} hodina",
+            "hours_few": "{{count}} hodiny",
             "hours_other": "{{count}} hodin",
             "minutes_one": "{{count}} minuta",
+            "minutes_few": "{{count}} minuty",
             "minutes_other": "{{count}} minut"
         },
         "link_modal": {
             "title": "Odkaz pro odesílatele",
-            "description": "Pošlete tento odkaz osobě, která má tajemství poskytnout. Pomocí odkazu může tajemství zadat a zašifrovat.",
+            "description": "Pošlete tento odkaz osobě, která má secret poskytnout. Pomocí odkazu může secret zadat a zašifrovat.",
             "copy_button": "Kopírovat odkaz",
             "close_button": "Zavřít",
-            "warning": "Tento odkaz lze použít pouze jednou. Po odeslání tajemství už nebude fungovat."
+            "warning": "Tento odkaz lze použít pouze jednou. Po odeslání secretu už nebude fungovat."
         },
         "cancel_modal": {
             "title": "Zrušit žádost",
@@ -877,9 +880,9 @@
         }
     },
     "create_request_page": {
-        "title": "Vytvořit žádost o tajemství",
-        "description": "Vyžádejte si od někoho tajemství vytvořením bezpečného odkazu pro jeho odeslání",
-        "back_button": "Zpět na žádosti o tajemství",
+        "title": "Vytvořit žádost o secret",
+        "description": "Vyžádejte si od někoho secret vytvořením bezpečného odkazu pro jeho odeslání",
+        "back_button": "Zpět na žádosti o secrety",
         "form": {
             "title_label": "Název žádosti",
             "title_placeholder": "např. Přístupové údaje AWS pro projekt X",
@@ -887,21 +890,21 @@
             "description_placeholder": "Doplňte kontext k požadovaným údajům...",
             "link_validity_label": "Platnost odkazu",
             "link_validity_hint": "Jak dlouho zůstane odkaz pro odesílatele aktivní",
-            "secret_settings_title": "Nastavení tajemství",
-            "secret_settings_description": "Tato nastavení se použijí na vytvořené tajemství",
-            "secret_expiration_label": "Platnost tajemství",
+            "secret_settings_title": "Nastavení secretu",
+            "secret_settings_description": "Tato nastavení se použijí na vytvořený secret",
+            "secret_expiration_label": "Platnost secretu",
             "max_views_label": "Maximální zobrazení",
             "password_label": "Ochrana heslem (volitelné)",
             "password_placeholder": "Zadejte heslo (min. 5 znaků)",
-            "password_hint": "Příjemci budou potřebovat toto heslo pro zobrazení tajemství",
+            "password_hint": "Příjemci budou potřebovat toto heslo pro zobrazení secretu",
             "ip_restriction_label": "Omezení podle IP (volitelné)",
             "ip_restriction_placeholder": "192.168.1.0/24 nebo 203.0.113.5",
-            "prevent_burn_label": "Zabránit automatickému zničení (ponechat tajemství i po dosažení maxima zobrazení)",
+            "prevent_burn_label": "Zabránit automatickému zničení (ponechat secret i po dosažení maxima zobrazení)",
             "webhook_title": "Oznámení webhookem (volitelné)",
-            "webhook_description": "Nechat se informovat po odeslání tajemství",
+            "webhook_description": "Nechat se informovat po odeslání secretu",
             "webhook_url_label": "URL webhooku",
             "webhook_url_placeholder": "https://vas-server.cz/webhook",
-            "webhook_url_hint": "Doporučeno HTTPS. Oznámení bude odesláno při vytvoření tajemství.",
+            "webhook_url_hint": "Doporučeno HTTPS. Oznámení bude odesláno při vytvoření secretu.",
             "creating_button": "Vytváření...",
             "create_button": "Vytvořit žádost"
         },
@@ -916,17 +919,17 @@
         },
         "success": {
             "title": "Žádost byla vytvořena!",
-            "description": "Sdílejte odkaz s osobou, která má tajemství poskytnout",
+            "description": "Sdílejte odkaz s osobou, která má secret poskytnout",
             "creator_link_label": "Odkaz pro odesílatele",
-            "webhook_secret_label": "Tajemství webhooku",
+            "webhook_secret_label": "Webhook secret",
             "webhook_secret_warning": "Tuto hodnotu si nyní uložte. Už se znovu nezobrazí a slouží k ověření podpisů webhooku.",
             "expires_at": "Platnost odkazu končí: {{date}}",
             "create_another_button": "Vytvořit další žádost",
             "view_all_button": "Zobrazit všechny žádosti"
         },
         "toast": {
-            "created": "Žádost o tajemství byla úspěšně vytvořena",
-            "create_error": "Žádost o tajemství se nepodařilo vytvořit",
+            "created": "Žádost o secret byla úspěšně vytvořena",
+            "create_error": "Žádost o secret se nepodařilo vytvořit",
             "copied": "Zkopírováno do schránky"
         }
     },
@@ -941,24 +944,24 @@
             "go_home_button": "Přejít na domovskou stránku"
         },
         "form": {
-            "title": "Odeslat tajemství",
-            "description": "Někdo vás požádal o bezpečné sdílení tajemství",
-            "password_protected_note": "Toto tajemství bude chráněno heslem",
-            "encryption_note": "Tajemství se před odesláním zašifruje ve vašem prohlížeči. Dešifrovací klíč bude pouze ve výsledné URL, kterou budete sdílet.",
+            "title": "Odeslat secret",
+            "description": "Někdo vás požádal o bezpečné sdílení secretu",
+            "password_protected_note": "Tento secret bude chráněn heslem",
+            "encryption_note": "Secret se před odesláním zašifruje ve vašem prohlížeči. Dešifrovací klíč bude pouze ve výsledné URL, kterou budete sdílet.",
             "submitting_button": "Šifrování a odesílání...",
-            "submit_button": "Odeslat tajemství"
+            "submit_button": "Odeslat secret"
         },
         "success": {
-            "title": "Tajemství bylo vytvořeno!",
-            "description": "Vaše tajemství bylo zašifrováno a bezpečně uloženo",
+            "title": "Secret byl vytvořen!",
+            "description": "Váš secret byl zašifrován a bezpečně uložen",
             "decryption_key_label": "Dešifrovací klíč",
             "warning": "Důležité: Dešifrovací klíč nyní zkopírujte a pošlete žadateli. Zobrazuje se naposledy.",
-            "manual_send_note": "Dešifrovací klíč musíte osobě, která si tajemství vyžádala, poslat ručně. URL tajemství už má ve svém přehledu.",
-            "create_own_button": "Vytvořit vlastní tajemství"
+            "manual_send_note": "Dešifrovací klíč musíte osobě, která si secret vyžádala, poslat ručně. URL secretu už má ve svém dashboardu.",
+            "create_own_button": "Vytvořit vlastní secret"
         },
         "toast": {
-            "created": "Tajemství bylo úspěšně odesláno",
-            "create_error": "Tajemství se nepodařilo odeslat",
+            "created": "Secret byl úspěšně odeslán",
+            "create_error": "Secret se nepodařilo odeslat",
             "copied": "Zkopírováno do schránky"
         }
     }

--- a/src/i18n/locales/cs/cs.json
+++ b/src/i18n/locales/cs/cs.json
@@ -1,0 +1,965 @@
+{
+    "template_selector": {
+        "button": "Šablony",
+        "description": "Rychlý start se šablonou",
+        "templates": {
+            "credentials": "Přihlašovací údaje",
+            "api_key": "API klíč",
+            "database": "Databáze",
+            "server": "Přístup k serveru",
+            "credit_card": "Platební karta",
+            "email": "Emailový účet"
+        }
+    },
+    "editor": {
+        "tooltips": {
+            "copy_text": "Kopírovat jako prostý text",
+            "copy_html": "Kopírovat jako HTML",
+            "copy_base64": "Kopírovat jako Base64",
+            "bold": "Tučné",
+            "italic": "Kurzíva",
+            "strikethrough": "Přeškrtnuté",
+            "inline_code": "Kód v řádku",
+            "link": "Odkaz",
+            "remove_link": "Odstranit odkaz",
+            "insert_password": "Vložit heslo",
+            "paragraph": "Odstavec",
+            "heading1": "Nadpis 1",
+            "heading2": "Nadpis 2",
+            "heading3": "Nadpis 3",
+            "bullet_list": "Odrážkový seznam",
+            "numbered_list": "Číslovaný seznam",
+            "blockquote": "Citace",
+            "code_block": "Blok kódu",
+            "undo": "Zpět",
+            "redo": "Znovu"
+        },
+        "copy_success": {
+            "html": "HTML zkopírováno!",
+            "text": "Text zkopírován!",
+            "base64": "Base64 zkopírováno!"
+        },
+        "link_modal": {
+            "title": "Přidat odkaz",
+            "url_label": "URL",
+            "url_placeholder": "Zadejte URL",
+            "cancel": "Zrušit",
+            "update": "Aktualizovat",
+            "insert": "Vložit"
+        },
+        "password_modal": {
+            "title": "Vygenerovat heslo",
+            "length_label": "Délka hesla",
+            "options_label": "Možnosti",
+            "include_numbers": "Číslice",
+            "include_symbols": "Symboly",
+            "include_uppercase": "Velká písmena",
+            "include_lowercase": "Malá písmena",
+            "generated_password": "Vygenerované heslo",
+            "refresh": "Vygenerovat znovu",
+            "cancel": "Zrušit",
+            "insert": "Vložit",
+            "copied_and_added": "Heslo přidáno a zkopírováno do schránky",
+            "added": "Heslo bylo přidáno"
+        },
+        "formatting_tools": "Nástroje formátování",
+        "character_count": "znaků"
+    },
+    "create_button": {
+        "creating_secret": "Vytváření tajemství...",
+        "create": "Vytvořit"
+    },
+    "file_upload": {
+        "sign_in_to_upload": "Pro nahrání souborů se přihlaste",
+        "sign_in": "Přihlásit se",
+        "drop_files_here": "Přetáhněte soubory sem",
+        "drag_and_drop": "Přetáhněte soubor nebo kliknutím vyberte soubor",
+        "uploading": "Nahrávání...",
+        "upload_file": "Nahrát soubor",
+        "file_too_large": "Soubor „{{fileName}}“ ({{fileSize}} MB) překračuje maximální velikost {{maxSize}} MB",
+        "max_size_exceeded": "Celková velikost souborů překračuje maximum {{maxSize}} MB"
+    },
+    "footer": {
+        "tagline": "Hemmelig, [heˈm(ɛ)li], znamená norsky „tajemství“",
+        "privacy": "Ochrana soukromí",
+        "terms": "Podmínky",
+        "api": "API",
+        "managed_hosting": "Správa hostingu"
+    },
+    "header": {
+        "home": "Domů",
+        "sign_in": "Přihlásit se",
+        "sign_up": "Registrovat se",
+        "dashboard": "Přehled",
+        "hero_text_part1": "Sdílejte tajemství bezpečně pomocí šifrovaných zpráv, které se po přečtení",
+        "hero_text_part2": " automaticky zničí",
+        "hero_text_part3": "."
+    },
+    "dashboard_layout": {
+        "secrets": "Tajemství",
+        "secret_requests": "Žádosti o tajemství",
+        "account": "Účet",
+        "analytics": "Analytika",
+        "users": "Uživatelé",
+        "invites": "Pozvánky",
+        "instance": "Instance",
+        "sign_out": "Odhlásit se",
+        "hemmelig": "Hemmelig"
+    },
+    "secret_settings": {
+        "secret_created_title": "Tajemství bylo vytvořeno!",
+        "secret_created_description": "Vaše tajemství je nyní dostupné na následující URL. Dešifrovací klíč bezpečně uschovejte, protože jej nelze obnovit.",
+        "secret_url_label": "URL tajemství",
+        "decryption_key_label": "Dešifrovací klíč",
+        "password_label": "Heslo",
+        "create_new_secret_button": "Vytvořit nové tajemství",
+        "copy_url_button": "Kopírovat URL",
+        "burn_secret_button": "Zničit tajemství",
+        "max_secrets_per_user_info": "Můžete vytvořit až {{count}} tajemství.",
+        "failed_to_burn": "Tajemství se nepodařilo zničit. Zkuste to znovu."
+    },
+    "security_settings": {
+        "security_title": "Zabezpečení",
+        "security_description": "Nastavte zabezpečení svého tajemství",
+        "remember_settings": "Zapamatovat",
+        "private_title": "Soukromé",
+        "private_description": "Soukromá tajemství jsou šifrovaná a lze je zobrazit pouze s dešifrovacím klíčem nebo heslem.",
+        "expiration_title": "Platnost",
+        "expiration_burn_after_time_description": "Nastavte, kdy se má tajemství zničit",
+        "expiration_default_description": "Nastavte, jak dlouho má být tajemství dostupné",
+        "max_views_title": "Maximum zobrazení",
+        "burn_after_time_mode_title": "Zničení po uplynutí času",
+        "burn_after_time_mode_description": "Tajemství se po uplynutí času zničí bez ohledu na počet zobrazení.",
+        "password_protection_title": "Ochrana heslem",
+        "password_protection_description": "Přidejte další vrstvu zabezpečení pomocí hesla",
+        "enter_password_label": "Zadejte heslo",
+        "password_placeholder": "Zadejte bezpečné heslo...",
+        "password_hint": "Minimálně 5 znaků. Příjemci budou toto heslo potřebovat k zobrazení tajemství",
+        "password_error": "Heslo musí mít alespoň 5 znaků",
+        "ip_restriction_title": "Omezit podle IP nebo CIDR",
+        "ip_restriction_description": "Pomocí CIDR můžete určit rozsahy IP adres, které smějí k tajemství přistupovat.",
+        "ip_address_cidr_label": "IP adresa nebo rozsah CIDR",
+        "ip_address_cidr_placeholder": "192.168.1.0/24 nebo 203.0.113.5",
+        "ip_address_cidr_hint": "K tajemství budou mít přístup pouze požadavky z těchto IP adres",
+        "burn_after_time_title": "Zničit po uplynutí času",
+        "burn_after_time_description": "Zničit tajemství až po uplynutí času"
+    },
+    "title_field": {
+        "placeholder": "Název",
+        "hint": "Dejte tajemství zapamatovatelný název (volitelné)"
+    },
+    "views_slider": {
+        "min_views": "1",
+        "max_views": "999",
+        "views_label": "zobrazení"
+    },
+    "account_page": {
+        "title": "Nastavení účtu",
+        "description": "Spravujte předvolby a zabezpečení svého účtu",
+        "tabs": {
+            "profile": "Profil",
+            "security": "Zabezpečení",
+            "developer": "Vývojář",
+            "danger_zone": "Nebezpečná zóna"
+        },
+        "profile_info": {
+            "title": "Informace o profilu",
+            "description": "Aktualizujte své osobní údaje",
+            "first_name_label": "Jméno",
+            "last_name_label": "Příjmení",
+            "username_label": "Uživatelské jméno",
+            "email_label": "E-mailová adresa",
+            "saving_button": "Ukládání...",
+            "save_changes_button": "Uložit změny"
+        },
+        "profile_settings": {
+            "username_taken": "Uživatelské jméno je již obsazeno"
+        },
+        "security_settings": {
+            "title": "Nastavení zabezpečení",
+            "description": "Spravujte heslo a bezpečnostní předvolby",
+            "change_password_title": "Změnit heslo",
+            "current_password_label": "Aktuální heslo",
+            "current_password_placeholder": "Zadejte aktuální heslo",
+            "new_password_label": "Nové heslo",
+            "new_password_placeholder": "Zadejte nové heslo",
+            "confirm_new_password_label": "Potvrďte nové heslo",
+            "confirm_new_password_placeholder": "Zadejte nové heslo znovu",
+            "password_mismatch_alert": "Nová hesla se neshodují",
+            "changing_password_button": "Měním...",
+            "change_password_button": "Změnit heslo",
+            "password_change_success": "Heslo se úspěšně změnilo!",
+            "password_change_error": "Nepodařilo se změnit heslo. Zkuste to prosím znovu."
+        },
+        "two_factor": {
+            "title": "Dvoufaktorové ověření",
+            "description": "Přidejte k účtu další vrstvu zabezpečení",
+            "enabled": "Zapnuto",
+            "disabled": "Není zapnuto",
+            "setup_button": "Nastavit 2FA",
+            "disable_button": "Vypnout 2FA",
+            "enter_password_to_enable": "Pro zapnutí dvoufaktorového ověření zadejte své heslo.",
+            "continue": "Pokračovat",
+            "scan_qr_code": "Naskenujte tento QR kód pomocí aplikace pro ověřování (Google Authenticator, Authy, atd.).",
+            "manual_entry_hint": "Nebo ručně zadejte tento kód ve vaší aplikaci:",
+            "enter_verification_code": "Zadejte 6místný kód z vaší aplikace pro ověření nastavení.",
+            "verification_code": "Ověřovací kód",
+            "verify_and_enable": "Ověřit a zapnout",
+            "back": "Zpět",
+            "disable_title": "Vypnout dvoufaktorové ověření",
+            "disable_warning": "Vypnutí 2FA sníží bezpečnost vašeho účtu. Pro potvrzení musíte zadat heslo.",
+            "invalid_password": "Neplatné heslo. Zkuste to prosím znovu.",
+            "invalid_code": "Neplatný ověřovací kód. Zkuste to prosím znovu.",
+            "enable_error": "2FA se nepodařilo zapnout. Zkuste to znovu.",
+            "verify_error": "Kód 2FA se nepodařilo ověřit. Zkuste to znovu.",
+            "disable_error": "2FA se nepodařilo vypnout. Zkuste to znovu.",
+            "backup_codes_title": "Záložní kódy",
+            "backup_codes_description": "Tyto záložní kódy uložte na bezpečné místo. Můžete je použít k přístupu ke svému účtu, pokud ztratíte přístup ke své aplikaci ověřovatele.",
+            "backup_codes_warning": "Každý kód lze použít pouze jednou. Uložte je bezpečně!",
+            "backup_codes_saved": "Záložní kódy mám uložené"
+        },
+        "danger_zone": {
+            "title": "Nebezpečná zóna",
+            "description": "Nevratné a destruktivní akce",
+            "delete_account_title": "Smazat účet",
+            "delete_account_description": "Smazání účtu je nevratné. Trvale odstraní váš účet, všechna vaše tajemství a související data.",
+            "delete_account_bullet1": "Všechna vaše tajemství budou trvale smazána",
+            "delete_account_bullet2": "Data vašeho účtu budou odstraněna z našich serverů",
+            "delete_account_bullet3": "Jakékoli sdílené tajné odkazy budou neplatné",
+            "delete_account_bullet4": "Tuto akci nelze vrátit zpět",
+            "delete_account_confirm": "Jste si jisti, že chcete smazat svůj účet? Tuto akci nelze zrušit.",
+            "delete_account_button": "Smazat účet",
+            "deleting_account_button": "Smazání účtu..."
+        },
+        "developer": {
+            "title": "API klíče",
+            "description": "Spravujte API klíče pro programový přístup",
+            "create_key": "Vytvořit klíč",
+            "create_key_title": "Vytvořit API klíč",
+            "key_name": "Název klíče",
+            "key_name_placeholder": "např. Moje integrace",
+            "expiration": "Platnost",
+            "never_expires": "Bez omezení platnosti",
+            "expires_30_days": "30 dní",
+            "expires_90_days": "90 dní",
+            "expires_1_year": "1 rok",
+            "create_button": "Vytvořit",
+            "name_required": "Je vyžadován název klíče",
+            "create_error": "Nepodařilo se vytvořit API klíč",
+            "key_created": "API klíč byl vytvořen!",
+            "key_warning": "Klíč si nyní zkopírujte. Později jej už nebude možné zobrazit.",
+            "dismiss": "Klíč mám zkopírovaný",
+            "no_keys": "Zatím nemáte žádné API klíče. Začněte vytvořením prvního.",
+            "created": "Vytvořeno",
+            "last_used": "Poslední použité",
+            "expires": "Platí",
+            "docs_hint": "Zjistěte, jak používat API klíče v",
+            "api_docs": "Dokumentace API"
+        }
+    },
+    "analytics_page": {
+        "title": "Analytika",
+        "description": "Sledujte aktivitu a přehledy sdílených tajemství",
+        "time_range": {
+            "last_7_days": "Posledních 7 dní",
+            "last_14_days": "Posledních 14 dní",
+            "last_30_days": "Posledních 30 dní"
+        },
+        "total_secrets": "Celkem tajemství",
+        "from_last_period": "+{{percentage}} % oproti minulému období",
+        "total_views": "Celkem zobrazení",
+        "avg_views_per_secret": "Průměr zobrazení na tajemství",
+        "active_secrets": "Aktivní tajemství",
+        "daily_activity": {
+            "title": "Denní aktivita",
+            "description": "Vytvořená tajemství a zobrazení v čase",
+            "secrets": "Tajemství",
+            "views": "Zobrazení",
+            "secrets_created": "Vytvořená tajemství",
+            "secret_views": "Zobrazení tajemství",
+            "date": "Datum",
+            "trend": "Změna",
+            "vs_previous": "oproti předchozímu dni",
+            "no_data": "Zatím nejsou k dispozici žádné údaje o aktivitě."
+        },
+        "locale": "cs-CZ",
+        "top_countries": {
+            "title": "Nejčastější země",
+            "description": "Odkud jsou vaše tajemství zobrazována",
+            "views": "Zobrazení"
+        },
+        "secret_types": {
+            "title": "Typy tajemství",
+            "description": "Distribuce podle úrovně ochrany",
+            "password_protected": "Chráněno heslem",
+            "ip_restricted": "Omezeno IP",
+            "burn_after_time": "Zničení po čase"
+        },
+        "expiration_stats": {
+            "title": "Statistiky platnosti",
+            "description": "Jak dlouho tajemství obvykle vydrží",
+            "one_hour": "1 hodina",
+            "one_day": "1 den",
+            "one_week_plus": "1 týden a více"
+        },
+        "visitor_analytics": {
+            "title": "Analytika návštěvníků",
+            "description": "Zobrazení stránek a unikátní návštěvníci",
+            "unique": "Unikátní",
+            "views": "Zobrazení",
+            "date": "Datum",
+            "trend": "Změna",
+            "vs_previous": "oproti předchozímu dni",
+            "no_data": "Zatím nejsou k dispozici žádné údaje o návštěvách."
+        },
+        "secret_requests": {
+            "total": "Žádosti o tajemství",
+            "fulfilled": "Vyřízené žádosti"
+        },
+        "loading": "Načítám analytiku...",
+        "no_permission": "Nemáte povolení prohlížet si analytiku.",
+        "failed_to_fetch": "Nepodařilo se získat analytická data."
+    },
+    "instance_page": {
+        "title": "Nastavení instance",
+        "description": "Nastavte svou instanci Hemmelig",
+        "managed_mode": {
+            "title": "Spravovaný režim",
+            "description": "Tato instance je spravována pomocí proměnných prostředí. Nastavení jsou pouze ke čtení."
+        },
+        "tabs": {
+            "general": "Obecné",
+            "security": "Zabezpečení",
+            "organization": "Organizace",
+            "webhook": "Webhooky",
+            "metrics": "Metriky"
+        },
+        "system_status": {
+            "title": "Stav systému",
+            "description": "Stav a výkon instance",
+            "version": "Verze",
+            "uptime": "Doba provozu",
+            "memory": "Paměť",
+            "cpu_usage": "Použití CPU"
+        },
+        "general_settings": {
+            "title": "Obecná nastavení",
+            "description": "Základní nastavení instance",
+            "instance_name_label": "Název instance",
+            "logo_label": "Logo instance",
+            "logo_upload": "Nahrát logo",
+            "logo_remove": "Odstranit logo",
+            "logo_hint": "PNG, JPEG, GIF, SVG nebo WebP. Max 512KB.",
+            "logo_alt": "Logo instance",
+            "logo_invalid_type": "Neplatný typ souboru. Nahrajte prosím PNG, JPEG, GIF, SVG nebo WebP obrázek.",
+            "logo_too_large": "Soubor je příliš velký. Maximální velikost je 512KB.",
+            "default_expiration_label": "Výchozí platnost tajemství",
+            "max_secrets_per_user_label": "Maximum tajemství na uživatele",
+            "max_secret_size_label": "Maximální velikost tajemství (MB)",
+            "instance_description_label": "Popis instance",
+            "important_message_label": "Důležitá zpráva",
+            "important_message_placeholder": "Zadejte důležitou zprávu pro zobrazení pro všechny uživatele...",
+            "important_message_hint": "Tato zpráva se zobrazí jako varovný banner na domovské stránce. Podporuje formátování Markdown. Ponechte pole prázdné, pokud ji chcete skrýt.",
+            "allow_registration_title": "Povolit registraci",
+            "allow_registration_description": "Povolit novým uživatelům registraci",
+            "email_verification_title": "Ověření e-mailu",
+            "email_verification_description": "Vyžaduje se ověření e-mailem"
+        },
+        "saving_button": "Ukládání...",
+        "save_settings_button": "Uložit nastavení",
+        "security_settings": {
+            "title": "Nastavení zabezpečení",
+            "description": "Nastavit bezpečnostní a přístupové kontroly",
+            "rate_limiting_title": "Omezení frekvence",
+            "rate_limiting_description": "Zapnout omezení frekvence požadavků",
+            "max_password_attempts_label": "Maximální počet pokusů o zadání hesla",
+            "session_timeout_label": "Platnost relace (hodiny)",
+            "allow_file_uploads_title": "Povolit nahrávání souborů",
+            "allow_file_uploads_description": "Umožnit uživatelům připojit soubory k tajemstvím"
+        },
+        "email_settings": {
+            "title": "Nastavení e-mailu",
+            "description": "Nastavit SMTP a e-mailová oznámení",
+            "smtp_host_label": "SMTP hostitel",
+            "smtp_port_label": "Port SMTP",
+            "username_label": "Uživatelské jméno",
+            "password_label": "Heslo"
+        },
+        "database_info": {
+            "title": "Databázové informace",
+            "description": "Stav databáze a statistiky",
+            "stats_title": "Databázové údaje",
+            "total_secrets": "Tajemství celkem:",
+            "total_users": "Uživatelé celkem:",
+            "disk_usage": "Použití disků:",
+            "connection_status_title": "Stav připojení",
+            "connected": "Připojeno",
+            "connected_description": "Databáze je zdravá a reaguje normálně."
+        },
+        "system_info": {
+            "title": "Informace o systému",
+            "description": "Detaily a údržba serveru",
+            "system_info_title": "Informace o systému",
+            "version": "Verze:",
+            "uptime": "Doba provozu:",
+            "status": "Stav:",
+            "resource_usage_title": "Využití zdrojů",
+            "memory": "Paměť:",
+            "cpu": "CPU:",
+            "disk": "Disk:"
+        },
+        "maintenance_actions": {
+            "title": "Údržba",
+            "description": "Tyto akce mohou ovlivnit dostupnost systému. Používejte s opatrností.",
+            "restart_service_button": "Restartovat službu",
+            "clear_cache_button": "Vyčistit mezipaměť",
+            "export_logs_button": "Exportovat záznamy"
+        }
+    },
+    "secrets_page": {
+        "title": "Vaše tajemství",
+        "description": "Spravujte a sledujte svá sdílená tajemství",
+        "create_secret_button": "Vytvořit tajemství",
+        "search_placeholder": "Vyhledávání tajemství...",
+        "filter": {
+            "all_secrets": "Všechna tajemství",
+            "active": "Aktivní",
+            "expired": "Po platnosti"
+        },
+        "total_secrets": "Celkem tajemství",
+        "active_secrets": "Aktivní",
+        "expired_secrets": "Po platnosti",
+        "no_secrets_found_title": "Nebyla nalezena žádná tajemství",
+        "no_secrets_found_description_filter": "Zkuste upravit kritéria vyhledávání nebo filtru.",
+        "no_secrets_found_description_empty": "Začněte vytvořením prvního tajemství.",
+        "password_protected": "Heslo",
+        "files": "soubory",
+        "table": {
+            "secret_header": "Tajemství",
+            "created_header": "Vytvořeno",
+            "status_header": "Stav",
+            "views_header": "Zobrazení",
+            "actions_header": "Akce",
+            "untitled_secret": "Nepojmenované tajemství",
+            "expired_status": "Po platnosti",
+            "active_status": "Aktivní",
+            "never_expires": "Bez omezení platnosti",
+            "expired_time": "Po platnosti",
+            "views_left": "zbývajících zobrazení",
+            "copy_url_tooltip": "Kopírovat URL",
+            "open_secret_tooltip": "Otevřít tajemství",
+            "delete_secret_tooltip": "Smazat tajemství",
+            "delete_confirmation_title": "Jste si jistí?",
+            "delete_confirmation_text": "Tuto akci nelze vrátit zpět. Tajemství bude trvale smazáno.",
+            "delete_confirm_button": "Ano, smazat",
+            "delete_cancel_button": "Zrušit"
+        }
+    },
+    "users_page": {
+        "title": "Správa uživatelů",
+        "description": "Správa uživatelů a jejich oprávnění",
+        "add_user_button": "Přidat uživatele",
+        "search_placeholder": "Vyhledávání uživatelů...",
+        "filter": {
+            "all_roles": "Všechny role",
+            "admin": "Administrátor",
+            "user": "Uživatel",
+            "all_status": "Všechny stavy",
+            "active": "Aktivní",
+            "suspended": "Pozastavený",
+            "pending": "Čekající"
+        },
+        "total_users": "Uživatelé celkem",
+        "active_users": "Aktivní",
+        "admins": "Administrátoři",
+        "pending_users": "Čekající",
+        "no_users_found_title": "Nebyli nalezeni žádní uživatelé",
+        "no_users_found_description_filter": "Zkuste upravit kritéria vyhledávání nebo filtru.",
+        "no_users_found_description_empty": "Zatím nebyli přidáni žádní uživatelé.",
+        "table": {
+            "user_header": "Uživatel",
+            "role_header": "Role",
+            "status_header": "Stav",
+            "activity_header": "Činnost",
+            "last_login_header": "Poslední přihlášení",
+            "actions_header": "Akce",
+            "created_at": "Vytvořeno v"
+        },
+        "status": {
+            "active": "Aktivní",
+            "banned": "Zablokovaný"
+        },
+        "delete_user_modal": {
+            "title": "Smazat uživatele",
+            "confirmation_message": "Jste si jisti, že chcete smazat uživatele {{username}}? Tuto akci nelze odčinit.",
+            "confirm_button": "Smazat",
+            "cancel_button": "Zrušit"
+        },
+        "edit_user_modal": {
+            "title": "Upravit uživatele: {{username}}",
+            "username_label": "Uživatelské jméno",
+            "email_label": "E-mail",
+            "role_label": "Role",
+            "banned_label": "Zablokovaný",
+            "save_button": "Uložit",
+            "cancel_button": "Zrušit"
+        },
+        "add_user_modal": {
+            "title": "Přidat nového uživatele",
+            "name_label": "Jméno",
+            "username_label": "Uživatelské jméno",
+            "email_label": "E-mail",
+            "password_label": "Heslo",
+            "role_label": "Role",
+            "save_button": "Přidat uživatele",
+            "cancel_button": "Zrušit"
+        }
+    },
+    "forgot_password_page": {
+        "back_to_sign_in": "Zpět k přihlášení",
+        "check_email_title": "Zkontrolujte si e-mail",
+        "check_email_description": "Na adresu {{email}} jsme poslali odkaz pro obnovení hesla.",
+        "did_not_receive_email": "E-mail vám nepřišel? Zkontrolujte složku se spamem nebo to zkuste znovu.",
+        "try_again_button": "Zkusit znovu",
+        "forgot_password_title": "Zapomněli jste heslo?",
+        "forgot_password_description": "Pošleme vám pokyny k obnovení hesla.",
+        "email_label": "E-mail",
+        "email_placeholder": "Zadejte svůj e-mail",
+        "email_hint": "Zadejte e-mail spojený s vaším účtem",
+        "sending_button": "Posílám...",
+        "reset_password_button": "Obnovit heslo",
+        "remember_password": "Vzpomněli jste si na heslo?",
+        "sign_in_link": "Přihlásit se",
+        "unexpected_error": "Nastala neočekávaná chyba. Zkuste to prosím znovu."
+    },
+    "login_page": {
+        "back_to_hemmelig": "Zpět do Hemmelig",
+        "welcome_back": "Vítejte zpět v Hemmelig",
+        "welcome_back_title": "Vítejte zpět",
+        "welcome_back_description": "Přihlaste se ke svému účtu Hemmelig",
+        "username_label": "Uživatelské jméno",
+        "username_placeholder": "Zadejte uživatelské jméno",
+        "password_label": "Heslo",
+        "password_placeholder": "Zadejte heslo",
+        "forgot_password_link": "Zapomněli jste heslo?",
+        "signing_in_button": "Přihlašování...",
+        "sign_in_button": "Přihlásit se",
+        "or_continue_with": "Nebo pokračujte pomocí",
+        "continue_with_github": "Pokračovat přes GitHub",
+        "no_account_question": "Nemáte účet?",
+        "sign_up_link": "Registrovat se",
+        "unexpected_error": "Došlo k neočekávané chybě. Zkuste to znovu."
+    },
+    "register_page": {
+        "back_to_hemmelig": "Zpět do Hemmelig",
+        "join_hemmelig": "Připojte se k Hemmelig a sdílejte tajemství bezpečně",
+        "email_password_disabled_message": "Registrace e-mailem a heslem je vypnutá. Použijte jednu z možností přihlášení níže.",
+        "create_account_title": "Vytvořit účet",
+        "create_account_description": "Připojte se k Hemmelig a sdílejte tajemství bezpečně",
+        "username_label": "Uživatelské jméno",
+        "username_placeholder": "Zvolte uživatelské jméno",
+        "email_label": "E-mail",
+        "email_placeholder": "Zadejte svůj e-mail",
+        "password_label": "Heslo",
+        "password_placeholder": "Vytvořte heslo",
+        "password_strength_label": "Síla hesla",
+        "password_strength_levels": {
+            "very_weak": "Velmi slabé",
+            "weak": "Slabé",
+            "fair": "Přijatelné",
+            "good": "Dobré",
+            "strong": "Silné"
+        },
+        "confirm_password_label": "Potvrďte heslo",
+        "confirm_password_placeholder": "Zadejte heslo znovu",
+        "passwords_match": "Hesla se shodují",
+        "passwords_do_not_match": "Hesla se neshodují",
+        "password_mismatch_alert": "Hesla se neshodují",
+        "creating_account_button": "Vytváření účtu...",
+        "create_account_button": "Vytvořit účet",
+        "or_continue_with": "Nebo pokračujte pomocí",
+        "continue_with_github": "Pokračovat přes GitHub",
+        "already_have_account_question": "Už máte účet?",
+        "sign_in_link": "Přihlásit se",
+        "invite_code_label": "Kód pozvánky",
+        "invite_code_placeholder": "Zadejte kód pozvánky",
+        "invite_code_required": "Kód pozvánky je povinný",
+        "invalid_invite_code": "Neplatný kód pozvánky",
+        "failed_to_validate_invite": "Kód pozvánky se nepodařilo ověřit",
+        "unexpected_error": "Došlo k neočekávané chybě. Zkuste to znovu.",
+        "email_domain_not_allowed": "Doména e-mailu není povolena",
+        "account_already_exists": "Účet s tímto e-mailem již existuje. Přihlaste se."
+    },
+    "secret_form": {
+        "failed_to_create_secret": "Nepodařilo se vytvořit tajemství: {{errorMessage}}",
+        "failed_to_upload_file": "Nepodařilo se nahrát soubor: {{fileName}}"
+    },
+    "secret_page": {
+        "password_label": "Heslo",
+        "password_placeholder": "Zadejte heslo pro zobrazení tajemství",
+        "decryption_key_label": "Dešifrovací klíč",
+        "decryption_key_placeholder": "Zadejte dešifrovací klíč",
+        "view_secret_button": "Zobrazit tajemství",
+        "views_remaining_tooltip": "Zbývající zobrazení: {{count}}",
+        "loading_message": "Dešifrování tajemství...",
+        "files_title": "Přiložené soubory",
+        "secret_waiting_title": "Někdo s vámi sdílí tajemství",
+        "secret_waiting_description": "Tajemství je zašifrované a zobrazí se až po kliknutí na tlačítko níže.",
+        "one_view_remaining": "Tajemství lze zobrazit už jen jednou",
+        "views_remaining": "Tajemství lze zobrazit ještě {{count}}krát",
+        "view_warning": "Po zobrazení nelze tuto akci vrátit zpět",
+        "secret_revealed": "Tajemství",
+        "copy_secret": "Kopírovat do schránky",
+        "download": "Stáhnout",
+        "create_your_own": "Vytvořit vlastní tajemství",
+        "encrypted_secret": "Zašifrované tajemství",
+        "unlock_secret": "Odemknout tajemství",
+        "delete_secret": "Smazat tajemství",
+        "delete_modal_title": "Smazat tajemství",
+        "delete_modal_message": "Opravdu chcete toto tajemství smazat? Tuto akci nelze vrátit zpět.",
+        "decryption_failed": "Tajemství se nepodařilo dešifrovat. Zkontrolujte heslo nebo dešifrovací klíč.",
+        "fetch_error": "Při načítání tajemství došlo k chybě. Zkuste to znovu."
+    },
+    "expiration": {
+        "28_days": "28 dní",
+        "14_days": "14 dní",
+        "7_days": "7 dní",
+        "3_days": "3 dny",
+        "1_day": "1 den",
+        "12_hours": "12 hodin",
+        "4_hours": "4 hodiny",
+        "1_hour": "1 hodina",
+        "30_minutes": "30 minut",
+        "5_minutes": "5 minut"
+    },
+    "error_display": {
+        "clear_errors_button_title": "Smazat chyby"
+    },
+    "secret_not_found_page": {
+        "title": "Tajemství nebylo nalezeno",
+        "message": "Hledané tajemství neexistuje, vypršela jeho platnost nebo bylo zničeno.",
+        "error_details": "Podrobnosti chyby:",
+        "go_home_button": "Přejít na domovskou stránku"
+    },
+    "organization_page": {
+        "title": "Nastavení organizace",
+        "description": "Nastavte pravidla a řízení přístupu pro celou organizaci",
+        "registration_settings": {
+            "title": "Nastavení registrace",
+            "description": "Určete, jak se mohou uživatelé připojit k organizaci",
+            "invite_only_title": "Registrace pouze s pozvánkou",
+            "invite_only_description": "Uživatelé se mohou registrovat pouze s platným kódem pozvánky",
+            "require_registered_user_title": "Pouze registrovaní uživatelé",
+            "require_registered_user_description": "Pouze registrovaní uživatelé mohou vytvářet tajemství",
+            "disable_email_password_signup_title": "Vypnout registraci e-mailem a heslem",
+            "disable_email_password_signup_description": "Vypnout registraci e-mailem a heslem (pouze externí přihlášení)",
+            "allowed_domains_title": "Povolené e-mailové domény",
+            "allowed_domains_description": "Povolit registraci jen z určených e-mailových domén (oddělených čárkou, např. firma.cz, organizace.cz)",
+            "allowed_domains_placeholder": "firma.cz, organizace.cz",
+            "allowed_domains_hint": "Seznam e-mailových domén oddělených čárkou. Prázdná hodnota povolí všechny domény."
+        },
+        "invite_codes": {
+            "title": "Kódy pozvánek",
+            "description": "Vytvořit a spravovat kódy pozvánek pro nové uživatele",
+            "create_invite_button": "Vytvořit kód pozvánky",
+            "code_header": "Kód",
+            "uses_header": "Použití",
+            "expires_header": "Platí",
+            "actions_header": "Akce",
+            "unlimited": "Neomezené",
+            "never": "Nikdy",
+            "expired": "Po platnosti",
+            "no_invites": "Zatím žádné kódy pozvánek.",
+            "no_invites_description": "Vytvořte kód pozvánky, aby se mohli registrovat noví uživatelé",
+            "copy_tooltip": "Kopírovat kód",
+            "delete_tooltip": "Smazat kód"
+        },
+        "create_invite_modal": {
+            "title": "Vytvořit kód pozvánky",
+            "max_uses_label": "Max. použití",
+            "max_uses_placeholder": "Ponechte prázdné pro neomezený počet použití",
+            "expiration_label": "Platnost",
+            "expiration_options": {
+                "never": "Nikdy",
+                "24_hours": "24 hodin",
+                "7_days": "7 dní",
+                "30_days": "30 dní"
+            },
+            "cancel_button": "Zrušit",
+            "create_button": "Vytvořit"
+        },
+        "saving_button": "Ukládání...",
+        "save_settings_button": "Uložit nastavení"
+    },
+    "invites_page": {
+        "title": "Kódy pozvánek",
+        "description": "Správa kódů pozvánek pro nové registrace uživatelů",
+        "create_invite_button": "Vytvořit pozvánku",
+        "loading": "Načítání kódů pozvánek...",
+        "table": {
+            "code_header": "Kód",
+            "uses_header": "Použití",
+            "expires_header": "Platí",
+            "status_header": "Stav",
+            "never": "Nikdy"
+        },
+        "status": {
+            "active": "Aktivní",
+            "expired": "Po platnosti",
+            "used": "Použité",
+            "inactive": "Neaktivní"
+        },
+        "no_invites": "Zatím žádné kódy pozvánek.",
+        "create_modal": {
+            "title": "Vytvořit kód pozvánky",
+            "max_uses_label": "Maximální využití",
+            "expires_in_label": "Platnost (dny)"
+        },
+        "delete_modal": {
+            "title": "Deaktivovat kód pozvánky",
+            "confirm_text": "Deaktivovat",
+            "cancel_text": "Zrušit",
+            "message": "Opravdu chcete deaktivovat kód pozvánky {{code}}? Tuto akci nelze vrátit zpět."
+        },
+        "toast": {
+            "created": "Kód pozvánky byl vytvořen",
+            "deactivated": "Kód pozvánky byl deaktivován",
+            "copied": "Kód pozvánky byl zkopírován do schránky",
+            "fetch_error": "Nepodařilo se získat kódy pozvánek",
+            "create_error": "Kód pozvánky se nepodařilo vytvořit",
+            "delete_error": "Kód pozvánky se nepodařilo deaktivovat"
+        }
+    },
+    "social_login": {
+        "continue_with": "Přihlásit přes {{provider}}",
+        "sign_up_with": "Registrovat se přes {{provider}}"
+    },
+    "setup_page": {
+        "title": "Vítejte v Hemmelig",
+        "description": "Začněte vytvořením účtu administrátora",
+        "name_label": "Celé jméno",
+        "name_placeholder": "Zadejte celé jméno",
+        "username_label": "Uživatelské jméno",
+        "username_placeholder": "Zvolte uživatelské jméno",
+        "email_label": "E-mailová adresa",
+        "email_placeholder": "Zadejte svůj e-mail",
+        "password_label": "Heslo",
+        "password_placeholder": "Vytvořte heslo (min. 8 znaků)",
+        "confirm_password_label": "Potvrďte heslo",
+        "confirm_password_placeholder": "Zadejte heslo znovu",
+        "create_admin": "Vytvořit účet administrátora",
+        "creating": "Vytváření účtu...",
+        "success": "Účet administrátora byl úspěšně vytvořen. Přihlaste se.",
+        "error": "Účet administrátora se nepodařilo vytvořit",
+        "passwords_mismatch": "Hesla se neshodují",
+        "password_too_short": "Heslo musí být nejméně 8 znaků.",
+        "note": "Toto nastavení lze dokončit pouze jednou. Účet administrátora získá plný přístup ke správě instance."
+    },
+    "theme_toggle": {
+        "switch_to_light": "Přepnout do světelného režimu",
+        "switch_to_dark": "Přepnout do tmavého režimu"
+    },
+    "webhook_settings": {
+        "title": "Oznámení webhookem",
+        "description": "Informujte externí služby při zobrazení nebo zničení tajemství",
+        "enable_webhooks_title": "Zapnout webhooky",
+        "enable_webhooks_description": "Při událostech posílat HTTP POST požadavky na URL webhooku",
+        "webhook_url_label": "URL webhooku",
+        "webhook_url_placeholder": "https://example.com/webhook",
+        "webhook_url_hint": "URL, na kterou se budou posílat data webhooku",
+        "webhook_secret_label": "Tajemství webhooku",
+        "webhook_secret_placeholder": "Zadejte tajemství pro podpis HMAC",
+        "webhook_secret_hint": "Používá se k podepisování dat webhooku pomocí HMAC-SHA256. Podpis se posílá v hlavičce X-Hemmelig-Signature.",
+        "events_title": "Události webhooku",
+        "on_view_title": "Tajemství zobrazeno",
+        "on_view_description": "Odeslat webhook při zobrazení tajemství",
+        "on_burn_title": "Tajemství zničeno",
+        "on_burn_description": "Odeslat webhook při zničení nebo smazání tajemství"
+    },
+    "metrics_settings": {
+        "title": "Metriky Prometheus",
+        "description": "Zpřístupněte metriky pro monitoring pomocí Promethea",
+        "enable_metrics_title": "Zapnout metriky Prometheus",
+        "enable_metrics_description": "Zpřístupnit endpoint /api/metrics pro načítání Prometheem",
+        "metrics_secret_label": "Tajemství metrik",
+        "metrics_secret_placeholder": "Zadejte tajemství pro ověření",
+        "metrics_secret_hint": "Používá se jako Bearer token pro ověření požadavků na endpoint metrik. Prázdná hodnota vypne ověření (nedoporučuje se).",
+        "endpoint_info_title": "Informace o endpointu",
+        "endpoint_info_description": "Po zapnutí budou metriky dostupné na:",
+        "endpoint_auth_hint": "Při načítání metrik vložte tajemství jako Bearer token do hlavičky Authorization."
+    },
+    "verify_2fa_page": {
+        "back_to_login": "Zpět k přihlášení",
+        "title": "Dvoufaktorové ověření",
+        "description": "Zadejte 6místný kód z vaší aplikace ověřovatele",
+        "enter_code_hint": "Zadejte kód z vaší aplikace ověřovatele",
+        "verifying": "Ověřuji...",
+        "verify_button": "Ověřit",
+        "invalid_code": "Neplatný ověřovací kód. Zkuste to prosím znovu.",
+        "unexpected_error": "Nastala neočekávaná chyba. Zkuste to prosím znovu."
+    },
+    "common": {
+        "error": "Chyba",
+        "cancel": "Zrušit",
+        "confirm": "Potvrdit",
+        "ok": "OK",
+        "delete": "Smazat",
+        "deleting": "Mazání...",
+        "loading": "Načítání..."
+    },
+    "pagination": {
+        "showing": "Zobrazeno {{start}} až {{end}} z {{total}} výsledků",
+        "previous_page": "Předchozí stránka",
+        "next_page": "Další strana"
+    },
+    "not_found_page": {
+        "title": "Stránka nenalezena",
+        "message": "Tahle stránka se vypařila, stejně jako naše tajemství.",
+        "hint": "Stránka, kterou hledáte, neexistuje nebo byla přesunuta.",
+        "go_home_button": "Přejít domů",
+        "create_secret_button": "Vytvořit tajemství"
+    },
+    "error_boundary": {
+        "title": "Něco se pokazilo.",
+        "message": "Při zpracovávání vaší žádosti došlo k neočekávané chybě.",
+        "hint": "Vaše tajemství jsou stále v bezpečí. Zkuste stránku obnovit.",
+        "error_details": "Údaje o chybě:",
+        "unknown_error": "Nastala neznámá chyba.",
+        "try_again_button": "Zkusit znovu",
+        "go_home_button": "Přejít domů"
+    },
+    "secret_requests_page": {
+        "title": "Žádosti o tajemství",
+        "description": "Vyžádejte si tajemství od ostatních pomocí bezpečných odkazů",
+        "create_request_button": "Vytvořit žádost",
+        "no_requests": "Zatím nemáte žádné žádosti o tajemství. Začněte vytvořením první.",
+        "table": {
+            "title_header": "Název",
+            "status_header": "Stav",
+            "secret_expiry_header": "Platnost tajemství",
+            "link_expires_header": "Platnost odkazu",
+            "copy_link_tooltip": "Kopírovat odkaz pro odesílatele",
+            "view_secret_tooltip": "Zobrazit tajemství",
+            "cancel_tooltip": "Zrušit žádost"
+        },
+        "status": {
+            "pending": "Čekající",
+            "fulfilled": "Vyřízená",
+            "expired": "Po platnosti",
+            "cancelled": "Zrušená"
+        },
+        "time": {
+            "days_one": "{{count}} den",
+            "days_other": "{{count}} dní",
+            "hours_one": "{{count}} hodina",
+            "hours_other": "{{count}} hodin",
+            "minutes_one": "{{count}} minuta",
+            "minutes_other": "{{count}} minut"
+        },
+        "link_modal": {
+            "title": "Odkaz pro odesílatele",
+            "description": "Pošlete tento odkaz osobě, která má tajemství poskytnout. Pomocí odkazu může tajemství zadat a zašifrovat.",
+            "copy_button": "Kopírovat odkaz",
+            "close_button": "Zavřít",
+            "warning": "Tento odkaz lze použít pouze jednou. Po odeslání tajemství už nebude fungovat."
+        },
+        "cancel_modal": {
+            "title": "Zrušit žádost",
+            "message": "Opravdu chcete zrušit žádost „{{title}}“? Tuto akci nelze vrátit zpět.",
+            "confirm_text": "Zrušit žádost",
+            "cancel_text": "Ponechat žádost"
+        },
+        "toast": {
+            "copied": "Odkaz zkopírován do schránky",
+            "cancelled": "Žádost zrušena",
+            "fetch_error": "Nepodařilo se získat detaily žádosti",
+            "cancel_error": "Nepodařilo se zrušit žádost"
+        }
+    },
+    "create_request_page": {
+        "title": "Vytvořit žádost o tajemství",
+        "description": "Vyžádejte si od někoho tajemství vytvořením bezpečného odkazu pro jeho odeslání",
+        "back_button": "Zpět na žádosti o tajemství",
+        "form": {
+            "title_label": "Název žádosti",
+            "title_placeholder": "např. Přístupové údaje AWS pro projekt X",
+            "description_label": "Popis (volitelné)",
+            "description_placeholder": "Doplňte kontext k požadovaným údajům...",
+            "link_validity_label": "Platnost odkazu",
+            "link_validity_hint": "Jak dlouho zůstane odkaz pro odesílatele aktivní",
+            "secret_settings_title": "Nastavení tajemství",
+            "secret_settings_description": "Tato nastavení se použijí na vytvořené tajemství",
+            "secret_expiration_label": "Platnost tajemství",
+            "max_views_label": "Maximální zobrazení",
+            "password_label": "Ochrana heslem (volitelné)",
+            "password_placeholder": "Zadejte heslo (min. 5 znaků)",
+            "password_hint": "Příjemci budou potřebovat toto heslo pro zobrazení tajemství",
+            "ip_restriction_label": "Omezení podle IP (volitelné)",
+            "ip_restriction_placeholder": "192.168.1.0/24 nebo 203.0.113.5",
+            "prevent_burn_label": "Zabránit automatickému zničení (ponechat tajemství i po dosažení maxima zobrazení)",
+            "webhook_title": "Oznámení webhookem (volitelné)",
+            "webhook_description": "Nechat se informovat po odeslání tajemství",
+            "webhook_url_label": "URL webhooku",
+            "webhook_url_placeholder": "https://vas-server.cz/webhook",
+            "webhook_url_hint": "Doporučeno HTTPS. Oznámení bude odesláno při vytvoření tajemství.",
+            "creating_button": "Vytváření...",
+            "create_button": "Vytvořit žádost"
+        },
+        "validity": {
+            "30_days": "30 dní",
+            "14_days": "14 dní",
+            "7_days": "7 dní",
+            "3_days": "3 dny",
+            "1_day": "1 den",
+            "12_hours": "12 hodin",
+            "1_hour": "1 hodina"
+        },
+        "success": {
+            "title": "Žádost byla vytvořena!",
+            "description": "Sdílejte odkaz s osobou, která má tajemství poskytnout",
+            "creator_link_label": "Odkaz pro odesílatele",
+            "webhook_secret_label": "Tajemství webhooku",
+            "webhook_secret_warning": "Tuto hodnotu si nyní uložte. Už se znovu nezobrazí a slouží k ověření podpisů webhooku.",
+            "expires_at": "Platnost odkazu končí: {{date}}",
+            "create_another_button": "Vytvořit další žádost",
+            "view_all_button": "Zobrazit všechny žádosti"
+        },
+        "toast": {
+            "created": "Žádost o tajemství byla úspěšně vytvořena",
+            "create_error": "Žádost o tajemství se nepodařilo vytvořit",
+            "copied": "Zkopírováno do schránky"
+        }
+    },
+    "request_secret_page": {
+        "loading": "Načítání žádosti...",
+        "error": {
+            "title": "Žádost není dostupná",
+            "invalid_link": "Tento odkaz je neplatný nebo s ním bylo manipulováno.",
+            "not_found": "Žádost nebyla nalezena nebo je odkaz neplatný.",
+            "already_fulfilled": "Žádost již byla vyřízena nebo vypršela její platnost.",
+            "generic": "Při načítání žádosti došlo k chybě.",
+            "go_home_button": "Přejít na domovskou stránku"
+        },
+        "form": {
+            "title": "Odeslat tajemství",
+            "description": "Někdo vás požádal o bezpečné sdílení tajemství",
+            "password_protected_note": "Toto tajemství bude chráněno heslem",
+            "encryption_note": "Tajemství se před odesláním zašifruje ve vašem prohlížeči. Dešifrovací klíč bude pouze ve výsledné URL, kterou budete sdílet.",
+            "submitting_button": "Šifrování a odesílání...",
+            "submit_button": "Odeslat tajemství"
+        },
+        "success": {
+            "title": "Tajemství bylo vytvořeno!",
+            "description": "Vaše tajemství bylo zašifrováno a bezpečně uloženo",
+            "decryption_key_label": "Dešifrovací klíč",
+            "warning": "Důležité: Dešifrovací klíč nyní zkopírujte a pošlete žadateli. Zobrazuje se naposledy.",
+            "manual_send_note": "Dešifrovací klíč musíte osobě, která si tajemství vyžádala, poslat ručně. URL tajemství už má ve svém přehledu.",
+            "create_own_button": "Vytvořit vlastní tajemství"
+        },
+        "toast": {
+            "created": "Tajemství bylo úspěšně odesláno",
+            "create_error": "Tajemství se nepodařilo odeslat",
+            "copied": "Zkopírováno do schránky"
+        }
+    }
+}

--- a/tests/e2e/i18n.spec.ts
+++ b/tests/e2e/i18n.spec.ts
@@ -15,3 +15,13 @@ test('should resolve regional Portuguese and render translated labels', async ({
 
     await expect(page.getByText(/Força da senha:\s+Muito Fraca/)).toBeVisible();
 });
+
+test('should resolve regional Czech and render translated labels', async ({ page }) => {
+    await page.addInitScript(() => {
+        window.localStorage.setItem('hemmelig-language', 'cs-CZ');
+    });
+    await page.goto('/register');
+
+    await expect(page.getByPlaceholder('Vytvořte heslo')).toBeVisible();
+    await expect(page.getByText('Vytvořit účet', { exact: true }).first()).toBeVisible();
+});

--- a/tests/i18n-czech.test.mjs
+++ b/tests/i18n-czech.test.mjs
@@ -1,3 +1,4 @@
+import i18next from 'i18next';
 import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 import test from 'node:test';
@@ -29,10 +30,66 @@ test('Czech locale translates the login action', async () => {
     assert.equal(czech.login_page.sign_in_button, 'Přihlásit se');
 });
 
-test('Czech locale has exact key parity with English', async () => {
-    const [english, czech] = await Promise.all([readLocale('en'), readLocale('cs')]);
+test('Czech locale keeps Secret and Dashboard as product terms', async () => {
+    const czech = await readLocale('cs');
 
-    assert.deepEqual(scalarPaths(czech).sort(), scalarPaths(english).sort());
+    assert.equal(czech.header.dashboard, 'Dashboard');
+    assert.equal(czech.dashboard_layout.secrets, 'Secrets');
+    assert.equal(czech.secrets_page.table.secret_header, 'Secret');
+    assert.equal(czech.secret_settings.create_new_secret_button, 'Vytvořit nový secret');
+
+    const dictionaryMeaning = czech.footer.tagline;
+    const productCopy = scalarEntries(czech)
+        .filter(([path]) => path !== 'footer.tagline')
+        .map(([, value]) => value)
+        .join('\n');
+
+    assert.match(dictionaryMeaning, /tajemství/u);
+    assert.doesNotMatch(productCopy, /tajemstv|tajemn/u);
+});
+
+test('Czech locale renders one, few, and other time plurals', async () => {
+    const [english, czech] = await Promise.all([readLocale('en'), readLocale('cs')]);
+    const i18n = i18next.createInstance();
+
+    await i18n.init({
+        lng: 'cs',
+        fallbackLng: 'en',
+        resources: {
+            cs: { translation: czech },
+            en: { translation: english },
+        },
+    });
+
+    for (const [unit, cases] of Object.entries({
+        days: ['1 den', '2 dny', '4 dny', '5 dní'],
+        hours: ['1 hodina', '2 hodiny', '4 hodiny', '5 hodin'],
+        minutes: ['1 minuta', '2 minuty', '4 minuty', '5 minut'],
+    })) {
+        for (const [index, count] of [1, 2, 4, 5].entries()) {
+            assert.equal(i18n.t(`secret_requests_page.time.${unit}`, { count }), cases[index]);
+        }
+    }
+});
+
+test('Czech locale contains every English key and only Czech plural extensions', async () => {
+    const [english, czech] = await Promise.all([readLocale('en'), readLocale('cs')]);
+    const englishPaths = scalarPaths(english).sort();
+    const czechPaths = scalarPaths(czech).sort();
+    const czechPluralExtensions = [
+        'secret_requests_page.time.days_few',
+        'secret_requests_page.time.hours_few',
+        'secret_requests_page.time.minutes_few',
+    ];
+
+    assert.deepEqual(
+        czechPaths.filter((path) => !czechPluralExtensions.includes(path)),
+        englishPaths
+    );
+    assert.deepEqual(
+        czechPaths.filter((path) => !englishPaths.includes(path)),
+        czechPluralExtensions
+    );
 });
 
 test('Czech locale preserves every runtime placeholder', async () => {

--- a/tests/i18n-czech.test.mjs
+++ b/tests/i18n-czech.test.mjs
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+const readLocale = async (locale) =>
+    JSON.parse(
+        await readFile(new URL(`../src/i18n/locales/${locale}/${locale}.json`, import.meta.url))
+    );
+
+const scalarPaths = (value, prefix = '') =>
+    Object.entries(value).flatMap(([key, child]) => {
+        const path = prefix ? `${prefix}.${key}` : key;
+        return child !== null && typeof child === 'object' ? scalarPaths(child, path) : [path];
+    });
+
+const scalarEntries = (value, prefix = '') =>
+    Object.entries(value).flatMap(([key, child]) => {
+        const path = prefix ? `${prefix}.${key}` : key;
+        return child !== null && typeof child === 'object'
+            ? scalarEntries(child, path)
+            : [[path, String(child)]];
+    });
+
+const placeholders = (text) => [...text.matchAll(/\{\{[^{}]+\}\}/g)].map(([value]) => value).sort();
+
+test('Czech locale translates the login action', async () => {
+    const czech = await readLocale('cs');
+
+    assert.equal(czech.login_page.sign_in_button, 'Přihlásit se');
+});
+
+test('Czech locale has exact key parity with English', async () => {
+    const [english, czech] = await Promise.all([readLocale('en'), readLocale('cs')]);
+
+    assert.deepEqual(scalarPaths(czech).sort(), scalarPaths(english).sort());
+});
+
+test('Czech locale preserves every runtime placeholder', async () => {
+    const [english, czech] = await Promise.all([readLocale('en'), readLocale('cs')]);
+    const czechByPath = new Map(scalarEntries(czech));
+
+    for (const [path, source] of scalarEntries(english)) {
+        assert.deepEqual(placeholders(czechByPath.get(path)), placeholders(source), path);
+    }
+});


### PR DESCRIPTION
## Summary

- add a complete Czech (`cs`) locale for the current v7 translation schema
- register Czech in i18next and the language picker without changing the upstream default language
- add recursive key-parity, interpolation-placeholder, and regional `cs-CZ` browser coverage

Czech was previously contributed and merged for the pre-v7 application in #194. This restores the locale for the rewritten v7 UI.

## Verification

- `node --test tests/i18n-czech.test.mjs`
- `npx prettier --check src/i18n/i18n.ts src/components/LanguagePicker.tsx src/i18n/locales/cs/cs.json tests/i18n-czech.test.mjs tests/e2e/i18n.spec.ts`
- `npx tsc --noEmit`
- `npm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Czech language support throughout the application.
  * Czech is now available in the language picker.
  * Added localized UI text for authentication, dashboards, settings, secrets, analytics, and other workflows.

* **Tests**
  * Added coverage verifying Czech language selection, translation completeness, and placeholder consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->