### PR TITLE
Fix attachment names when file IDs contain hyphens

### DIFF
--- a/src/pages/SecretPage.tsx
+++ b/src/pages/SecretPage.tsx
@@ -20,6 +20,7 @@ import { Modal } from '../components/Modal';
 import { useCopyFeedback } from '../hooks/useCopyFeedback';
 import { api } from '../lib/api';
 import { decrypt, decryptFile, generateEncryptionKey } from '../lib/crypto';
+import { getOriginalFilename } from '../utils/filename';
 
 interface SecretFile {
     id: string;
@@ -146,7 +147,7 @@ export function SecretPage() {
         const blob = new Blob([decryptedFile]);
         const link = document.createElement('a');
         link.href = URL.createObjectURL(blob);
-        link.download = file.filename.split('-').slice(1).join('-');
+        link.download = getOriginalFilename(file);
         link.click();
         URL.revokeObjectURL(link.href);
     };
@@ -341,7 +342,7 @@ export function SecretPage() {
                                                 <FileIcon className="w-4 h-4" />
                                             </div>
                                             <span className="text-sm text-gray-700 dark:text-slate-300">
-                                                {file.filename.split('-').slice(1).join('-')}
+                                                {getOriginalFilename(file)}
                                             </span>
                                         </div>
                                         <button

--- a/src/pages/SecretPage.tsx
+++ b/src/pages/SecretPage.tsx
@@ -33,6 +33,7 @@ interface SecretLoaderData {
     files: SecretFile[];
 }
 
+/** Display a shared secret and let its recipient decrypt and download attachments. */
 export function SecretPage() {
     const { t } = useTranslation();
     const { id } = useParams<{ id: string }>();

--- a/src/utils/filename.ts
+++ b/src/utils/filename.ts
@@ -1,3 +1,4 @@
+/** Restore an attachment name by removing its complete storage ID prefix. */
 export function getOriginalFilename(file: { id: string; filename: string }): string {
     const prefix = `${file.id}-`;
     return file.filename.startsWith(prefix) ? file.filename.slice(prefix.length) : file.filename;

--- a/src/utils/filename.ts
+++ b/src/utils/filename.ts
@@ -1,0 +1,4 @@
+export function getOriginalFilename(file: { id: string; filename: string }): string {
+    const prefix = `${file.id}-`;
+    return file.filename.startsWith(prefix) ? file.filename.slice(prefix.length) : file.filename;
+}

--- a/tests/unit/filename.test.mjs
+++ b/tests/unit/filename.test.mjs
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { getOriginalFilename } from '../../src/utils/filename.ts';
+
+for (const id of [
+    'abcdefghijklmnopqrstu',
+    'ab-cdefghijklmnopqrst',
+    '-abcdefghijklmnopqrst',
+    'abcdefghijklmnopqrst-',
+]) {
+    test(`restores attachment names for file ID ${id}`, () => {
+        for (const filename of ['report.txt', 'my-report-final.txt', '-notes.txt', 'notes']) {
+            assert.equal(getOriginalFilename({ id, filename: `${id}-${filename}` }), filename);
+        }
+    });
+}
+
+test('preserves filenames without the matching storage prefix', () => {
+    for (const filename of ['report.txt', 'other-id-report.txt']) {
+        assert.equal(getOriginalFilename({ id: 'file-id', filename }), filename);
+    }
+});

--- a/tests/unit/filename.test.mjs
+++ b/tests/unit/filename.test.mjs
@@ -3,13 +3,13 @@ import { test } from 'node:test';
 import { getOriginalFilename } from '../../src/utils/filename.ts';
 
 for (const id of [
-    'abcdefghijklmnopqrstu',
-    'ab-cdefghijklmnopqrst',
-    '-abcdefghijklmnopqrst',
-    'abcdefghijklmnopqrst-',
+    'V7mQ2xR9pL4nK8sD6wZ3t',
+    'V7mQ2-R9pL4nK8sD6wZ3t',
+    '-7mQ2xR9pL4nK8sD6wZ3t',
+    'V7mQ2xR9pL4nK8sD6wZ3-',
 ]) {
     test(`restores attachment names for file ID ${id}`, () => {
-        for (const filename of ['report.txt', 'my-report-final.txt', '-notes.txt', 'notes']) {
+        for (const filename of ['report.pdf', 'team-notes-final.txt', '-draft.md', 'LICENSE']) {
             assert.equal(getOriginalFilename({ id, filename: `${id}-${filename}` }), filename);
         }
     });


### PR DESCRIPTION
## Summary

Attachments are stored as `${file.id}-${sanitizedFilename}`, but file IDs can contain hyphens. SecretPage previously removed everything through the first hyphen, leaving part of the ID in displayed and downloaded names. This adds a helper that removes only the known `${file.id}-` prefix and uses it in both places.

## Testing

Ran in hardened offline Docker with Node 25:

```sh
node --test tests/unit/filename.test.mjs
```

All 5 tests pass, covering hyphenated IDs, edge-position hyphens, filenames with hyphens, and unmatched prefixes. The same tests failed 4 cases with the old expression extracted into the helper. The application, browser flow, and full build were not run.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - File names now display correctly in file lists by removing only the matching storage identifier prefix.
  - Downloaded files now use their original names instead of retaining storage-generated prefixes.
  - File names without a matching prefix remain unchanged.

- **Tests**
  - Added coverage for original filename handling across multiple identifier formats and unchanged filenames.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->